### PR TITLE
Allow altering config values based on request

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,31 +44,34 @@ Add ``'adyen'`` to ``INSTALLED_APPS`` and run::
 to create the appropriate database tables.
 
 Configuration
--------------
+=============
+
+You have two approaches to configure `django-oscar-adyen`.
+
+Settings-based configuration
+----------------------------
+For simple deployments, setting the required values in the settings will suffice.
 
 Edit your ``settings.py`` to set the following settings:
 
-.. code-block:: python
+* ``ADYEN_IDENTIFIER`` - The identifier of your Adyen account.
+* ``ADYEN_SKIN_CODE`` -  The code for your Adyen skin.
+* ``ADYEN_SECRET_KEY`` - The secret key defined in your Adyen skin.
+* ``ADYEN_ACTION_URL`` -
+  The URL towards which the Adyen form should be POSTed to initiate the payment process
+  (e.g. 'https://test.adyen.com/hpp/select.shtml').
+* ``ADYEN_IP_ADDRESS_HTTP_HEADER`` - Optional. The header in `META` to inspect to determine
+  the IP address of the request. Defaults to `REMOTE_ADDR`.
 
-    ADYEN_IDENTIFIER = 'YourAdyenAccountName'
-    ADYEN_SECRET_KEY = 'YourAdyenSkinSecretKey'
-    ADYEN_ACTION_URL = 'https://test.adyen.com/hpp/select.shtml'
-
-Obviously, you'll need to specify different settings in your test environment
+You will likely need to specify different settings in your test environment
 as opposed to your production environment.
 
-
-Settings
-========
-
-====================== =========================================================
- Setting                Description
----------------------- ---------------------------------------------------------
- ``ADYEN_IDENTIFIER``   The identifier of your Adyen account
- ``ADYEN_SECRET_KEY``   The secret key defined in your Adyen skin
- ``ADYEN_ACTION_URL``   The URL towards which the Adyen form should be POSTed
-                        to initiate the payment process
-====================== =========================================================
+Class-based configuration
+-------------------------
+In more complex deployments, you will want to e.g. alter the Adyen identifier based on
+the request. That is not easily implemented with Django settings, so you can alternatively
+set ``ADYEN_CONFIG_CLASS`` to a config class of your own.
+See `adyen.settings_config.FromSettingsConfig` for an example.
 
 License
 =======

--- a/adyen/config.py
+++ b/adyen/config.py
@@ -1,0 +1,35 @@
+from django.conf import settings
+from django.utils.module_loading import import_string
+
+
+def get_config():
+    """
+    Returns an instance of the configured config class.
+    """
+
+    try:
+        config_class_string = settings.ADYEN_CONFIG_CLASS
+    except AttributeError:
+        config_class_string = 'adyen.settings_config.FromSettingsConfig'
+    return import_string(config_class_string)()
+
+
+class AbstractAdyenConfig:
+    """
+    The base implementation for a config class.
+    """
+
+    def get_identifier(self):
+        raise NotImplementedError
+
+    def get_action_url(self):
+        raise NotImplementedError
+
+    def get_skin_code(self):
+        raise NotImplementedError
+
+    def get_skin_secret(self):
+        raise NotImplementedError
+
+    def get_ip_address_header(self):
+        raise NotImplementedError

--- a/adyen/config.py
+++ b/adyen/config.py
@@ -19,16 +19,16 @@ class AbstractAdyenConfig:
     The base implementation for a config class.
     """
 
-    def get_identifier(self):
+    def get_identifier(self, request):
         raise NotImplementedError
 
-    def get_action_url(self):
+    def get_action_url(self, request):
         raise NotImplementedError
 
-    def get_skin_code(self):
+    def get_skin_code(self, request):
         raise NotImplementedError
 
-    def get_skin_secret(self):
+    def get_skin_secret(self, request):
         raise NotImplementedError
 
     def get_ip_address_header(self):

--- a/adyen/scaffold.py
+++ b/adyen/scaffold.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-
-import bleach
-
 from django.utils import timezone
 
 from .facade import Facade
@@ -30,16 +26,6 @@ class Scaffold:
         return get_config().get_action_url(request)
 
     def get_form_fields(self, request, order_data):
-        """ Return the payment form fields, rendered into HTML. """
-
-        fields_list = self.get_form_fields_list(request, order_data)
-        return ''.join([
-            '<input type="%s" name="%s" value="%s">\n' % (
-                f.get('type'), f.get('name'), bleach.clean(f.get('value'))
-            ) for f in fields_list
-        ])
-
-    def get_form_fields_list(self, request, order_data):
         """
         Return the payment form fields as a list of dicts.
         Expects a large-ish order_data dictionary with details of the order.

--- a/adyen/scaffold.py
+++ b/adyen/scaffold.py
@@ -2,12 +2,11 @@
 
 import bleach
 
-from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
 from django.utils import timezone
 
 from .facade import Facade
 from .gateway import Constants, MissingFieldException
+from .config import get_config
 
 
 class Scaffold():
@@ -36,10 +35,7 @@ class Scaffold():
 
     def get_form_action(self):
         """ Return the URL where the payment form should be submitted. """
-        try:
-            return settings.ADYEN_ACTION_URL
-        except AttributeError:
-            raise ImproperlyConfigured("Please set ADYEN_ACTION_URL")
+        return get_config().get_action_url()
 
     def get_form_fields(self):
         """ Return the payment form fields, rendered into HTML. """
@@ -64,13 +60,13 @@ class Scaffold():
         # Build common field specs
         try:
             field_specs = {
-                Constants.MERCHANT_ACCOUNT: settings.ADYEN_IDENTIFIER,
+                Constants.MERCHANT_ACCOUNT: get_config().get_identifier(),
                 Constants.MERCHANT_REFERENCE: str(self.order_number),
                 Constants.SHOPPER_REFERENCE: self.client_id,
                 Constants.SHOPPER_EMAIL: self.client_email,
                 Constants.CURRENCY_CODE: self.currency_code,
                 Constants.PAYMENT_AMOUNT: self.amount,
-                Constants.SKIN_CODE: settings.ADYEN_SKIN_CODE,
+                Constants.SKIN_CODE: get_config().get_skin_code(),
                 Constants.SESSION_VALIDITY: session_validity.strftime(session_validity_format),
                 Constants.SHIP_BEFORE_DATE: ship_before_date.strftime(ship_before_date_format),
                 Constants.SHOPPER_LOCALE: self.shopper_locale,

--- a/adyen/scaffold.py
+++ b/adyen/scaffold.py
@@ -21,9 +21,12 @@ class Scaffold:
         Constants.PAYMENT_RESULT_REFUSED: PAYMENT_STATUS_REFUSED,
     }
 
+    def __init__(self):
+        self.config = get_config()
+
     def get_form_action(self, request):
         """ Return the URL where the payment form should be submitted. """
-        return get_config().get_action_url(request)
+        return self.config.get_action_url(request)
 
     def get_form_fields(self, request, order_data):
         """
@@ -39,8 +42,8 @@ class Scaffold:
         # Build common field specs
         try:
             field_specs = {
-                Constants.MERCHANT_ACCOUNT: get_config().get_identifier(request),
-                Constants.SKIN_CODE: get_config().get_skin_code(request),
+                Constants.MERCHANT_ACCOUNT: self.config.get_identifier(request),
+                Constants.SKIN_CODE: self.config.get_skin_code(request),
                 Constants.SESSION_VALIDITY: session_validity.strftime(session_validity_format),
                 Constants.SHIP_BEFORE_DATE: ship_before_date.strftime(ship_before_date_format),
 

--- a/adyen/settings_config.py
+++ b/adyen/settings_config.py
@@ -24,16 +24,16 @@ class FromSettingsConfig(AbstractAdyenConfig):
                 "You are using the FromSettingsConfig config class, but haven't set the "
                 "the following required settings: %s" % missing_settings)
 
-    def get_identifier(self):
+    def get_identifier(self, request):
         return settings.ADYEN_IDENTIFIER
 
-    def get_action_url(self):
+    def get_action_url(self, request):
         return settings.ADYEN_ACTION_URL
 
-    def get_skin_code(self):
+    def get_skin_code(self, request):
         return settings.ADYEN_SKIN_CODE
 
-    def get_skin_secret(self):
+    def get_skin_secret(self, request):
         return settings.ADYEN_SECRET_KEY
 
     def get_ip_address_header(self):

--- a/adyen/settings_config.py
+++ b/adyen/settings_config.py
@@ -1,0 +1,43 @@
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
+from .config import AbstractAdyenConfig
+
+
+class FromSettingsConfig(AbstractAdyenConfig):
+    """
+    This config class is enabled by default and useful in simple deployments.
+    One can just set all needed values in the Django settings. It also
+    exists for backwards-compatibility with previous deployments.
+    """
+
+    def __init__(self):
+        """
+        We complain as early as possible when Django settings are missing.
+        """
+        required_settings = [
+            'ADYEN_IDENTIFIER', 'ADYEN_ACTION_URL', 'ADYEN_SKIN_CODE', 'ADYEN_SECRET_KEY']
+        missing_settings = [
+            setting for setting in required_settings if not hasattr(settings, setting)]
+        if missing_settings:
+            raise ImproperlyConfigured(
+                "You are using the FromSettingsConfig config class, but haven't set the "
+                "the following required settings: %s" % missing_settings)
+
+    def get_identifier(self):
+        return settings.ADYEN_IDENTIFIER
+
+    def get_action_url(self):
+        return settings.ADYEN_ACTION_URL
+
+    def get_skin_code(self):
+        return settings.ADYEN_SKIN_CODE
+
+    def get_skin_secret(self):
+        return settings.ADYEN_SECRET_KEY
+
+    def get_ip_address_header(self):
+        try:
+            return settings.ADYEN_IP_ADDRESS_HTTP_HEADER
+        except AttributeError:
+            return 'REMOTE_ADDR'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-bleach==1.4
 iptools==0.6.1
 requests>=2.0.0,<3.0
 freezegun==0.1.18

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'bleach==1.4',
         'django-oscar>=0.7',
         'iptools==0.6.1',
         'requests>=2.0,<3.0',

--- a/tests/test_adyen.py
+++ b/tests/test_adyen.py
@@ -4,8 +4,6 @@ from copy import deepcopy
 import six
 from unittest.mock import Mock
 
-from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 from django.test.utils import override_settings
 
@@ -139,11 +137,6 @@ class TestAdyenPaymentRequest(AdyenTestCase):
         """
         action_url = self.scaffold.get_form_action()
         self.assertEqual(action_url, TEST_ACTION_URL)
-
-        # If the setting is missing, a proper exception is raised
-        del settings.ADYEN_ACTION_URL
-        with self.assertRaises(ImproperlyConfigured):
-            self.scaffold.get_form_action()
 
     def test_form_fields_ok(self):
         """

--- a/tests/test_adyen.py
+++ b/tests/test_adyen.py
@@ -100,6 +100,8 @@ TAMPERED_PAYMENT_PARAMS = {
     'skinCode': '4d72uQqA',
 }
 
+DUMMY_REQUEST = None
+
 
 @override_settings(
     ADYEN_IDENTIFIER=TEST_IDENTIFIER,
@@ -135,7 +137,7 @@ class TestAdyenPaymentRequest(AdyenTestCase):
         """
         Test that the form action is properly fetched from the settings.
         """
-        action_url = self.scaffold.get_form_action()
+        action_url = self.scaffold.get_form_action(DUMMY_REQUEST)
         self.assertEqual(action_url, TEST_ACTION_URL)
 
     def test_form_fields_ok(self):
@@ -143,7 +145,7 @@ class TestAdyenPaymentRequest(AdyenTestCase):
         Test that the payment form fields are properly built.
         """
         with freeze_time(TEST_FROZEN_TIME):
-            form_fields = self.scaffold.get_form_fields()
+            form_fields = self.scaffold.get_form_fields(DUMMY_REQUEST)
             for field_spec in EXPECTED_FIELDS_LIST:
                 field = '<input type="%s" name="%s" value="%s">' % (
                     field_spec.get('type'),
@@ -157,7 +159,7 @@ class TestAdyenPaymentRequest(AdyenTestCase):
         Test that the payment form fields list is properly built.
         """
         with freeze_time(TEST_FROZEN_TIME):
-            fields_list = self.scaffold.get_form_fields_list()
+            fields_list = self.scaffold.get_form_fields_list(DUMMY_REQUEST)
             self.assertEqual(len(fields_list), len(EXPECTED_FIELDS_LIST))
             for field in fields_list:
                 self.assertIn(field, EXPECTED_FIELDS_LIST)
@@ -170,7 +172,7 @@ class TestAdyenPaymentRequest(AdyenTestCase):
         del self.order_data['amount']
         scaffold = Scaffold(self.order_data)
         with self.assertRaises(MissingFieldException):
-            scaffold.get_form_fields_list()
+            scaffold.get_form_fields_list(DUMMY_REQUEST)
 
 
 class TestAdyenPaymentResponse(AdyenTestCase):

--- a/tests/test_adyen.py
+++ b/tests/test_adyen.py
@@ -142,29 +142,15 @@ class TestAdyenPaymentRequest(AdyenTestCase):
 
     def test_form_fields_ok(self):
         """
-        Test that the payment form fields are properly built.
-        """
-        with freeze_time(TEST_FROZEN_TIME):
-            form_fields = self.scaffold.get_form_fields(DUMMY_REQUEST, ORDER_DATA)
-            for field_spec in EXPECTED_FIELDS_LIST:
-                field = '<input type="%s" name="%s" value="%s">' % (
-                    field_spec.get('type'),
-                    field_spec.get('name'),
-                    field_spec.get('value'),
-                )
-                self.assertIn(field, form_fields)
-
-    def test_form_fields_list_ok(self):
-        """
         Test that the payment form fields list is properly built.
         """
         with freeze_time(TEST_FROZEN_TIME):
-            fields_list = self.scaffold.get_form_fields_list(DUMMY_REQUEST, ORDER_DATA)
+            fields_list = self.scaffold.get_form_fields(DUMMY_REQUEST, ORDER_DATA)
             self.assertEqual(len(fields_list), len(EXPECTED_FIELDS_LIST))
             for field in fields_list:
                 self.assertIn(field, EXPECTED_FIELDS_LIST)
 
-    def test_form_fields_list_with_missing_mandatory_field(self):
+    def test_form_fields_with_missing_mandatory_field(self):
         """
         Test that the proper exception is raised when trying
         to build a fields list with a missing mandatory field.
@@ -173,7 +159,7 @@ class TestAdyenPaymentRequest(AdyenTestCase):
         del new_order_data['amount']
 
         with self.assertRaises(MissingFieldException):
-            self.scaffold.get_form_fields_list(DUMMY_REQUEST, new_order_data)
+            self.scaffold.get_form_fields(DUMMY_REQUEST, new_order_data)
 
 
 class TestAdyenPaymentResponse(AdyenTestCase):

--- a/tests/test_adyen.py
+++ b/tests/test_adyen.py
@@ -100,6 +100,20 @@ TAMPERED_PAYMENT_PARAMS = {
     'skinCode': '4d72uQqA',
 }
 
+ORDER_DATA = {
+    'amount': 123,
+    'basket_id': 456,
+    'client_email': 'test@example.com',
+    'client_id': 789,
+    'currency_code': 'EUR',
+    'country_code': 'fr',
+    'description': 'Order #123',
+    'order_id': 'ORD-123',
+    'order_number': '00000000123',
+    'return_url': TEST_RETURN_URL,
+    'shopper_locale': 'fr',
+}
+
 DUMMY_REQUEST = None
 
 
@@ -113,21 +127,7 @@ class AdyenTestCase(TestCase):
 
     def setUp(self):
         super().setUp()
-
-        self.order_data = {
-            'amount': 123,
-            'basket_id': 456,
-            'client_email': 'test@example.com',
-            'client_id': 789,
-            'currency_code': 'EUR',
-            'country_code': 'fr',
-            'description': 'Order #123',
-            'order_id': 'ORD-123',
-            'order_number': '00000000123',
-            'return_url': TEST_RETURN_URL,
-            'shopper_locale': 'fr',
-        }
-        self.scaffold = Scaffold(self.order_data)
+        self.scaffold = Scaffold()
 
 
 class TestAdyenPaymentRequest(AdyenTestCase):
@@ -145,7 +145,7 @@ class TestAdyenPaymentRequest(AdyenTestCase):
         Test that the payment form fields are properly built.
         """
         with freeze_time(TEST_FROZEN_TIME):
-            form_fields = self.scaffold.get_form_fields(DUMMY_REQUEST)
+            form_fields = self.scaffold.get_form_fields(DUMMY_REQUEST, ORDER_DATA)
             for field_spec in EXPECTED_FIELDS_LIST:
                 field = '<input type="%s" name="%s" value="%s">' % (
                     field_spec.get('type'),
@@ -159,7 +159,7 @@ class TestAdyenPaymentRequest(AdyenTestCase):
         Test that the payment form fields list is properly built.
         """
         with freeze_time(TEST_FROZEN_TIME):
-            fields_list = self.scaffold.get_form_fields_list(DUMMY_REQUEST)
+            fields_list = self.scaffold.get_form_fields_list(DUMMY_REQUEST, ORDER_DATA)
             self.assertEqual(len(fields_list), len(EXPECTED_FIELDS_LIST))
             for field in fields_list:
                 self.assertIn(field, EXPECTED_FIELDS_LIST)
@@ -169,10 +169,11 @@ class TestAdyenPaymentRequest(AdyenTestCase):
         Test that the proper exception is raised when trying
         to build a fields list with a missing mandatory field.
         """
-        del self.order_data['amount']
-        scaffold = Scaffold(self.order_data)
+        new_order_data = ORDER_DATA.copy()
+        del new_order_data['amount']
+
         with self.assertRaises(MissingFieldException):
-            scaffold.get_form_fields_list(DUMMY_REQUEST)
+            self.scaffold.get_form_fields_list(DUMMY_REQUEST, new_order_data)
 
 
 class TestAdyenPaymentResponse(AdyenTestCase):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,6 +4,8 @@ from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 from django.test.utils import override_settings
 
+# We use get_config() instead of adyen_config because throughout
+# the tests, we repeatedly change the Django settings.
 from adyen.config import get_config, AbstractAdyenConfig
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 from django.test.utils import override_settings
 
-from adyen.config import get_config
+from adyen.config import get_config, AbstractAdyenConfig
 
 
 @override_settings(
@@ -23,7 +23,7 @@ class FromSettingsTestCase(TestCase):
         assert 'FromSettingsConfig' in get_config().__class__.__name__
 
     def test_value_passing_works(self):
-        assert get_config().get_action_url() == 'foo'
+        assert get_config().get_action_url(None) == 'foo'
 
     # https://docs.djangoproject.com/en/1.8/topics/testing/tools/#django.test.modify_settings
     # Override settings is needed to let us delete settings on a per-test basis.
@@ -35,9 +35,9 @@ class FromSettingsTestCase(TestCase):
             get_config()
 
 
-class DummyConfigClass:
+class DummyConfigClass(AbstractAdyenConfig):
 
-    def get_action_url(self):
+    def get_action_url(self, request):
         return 'foo'
 
 
@@ -56,6 +56,6 @@ class CustomConfigClassTestCase(TestCase):
         """
         Check that we indeed ignore Django settings (apart from the config class).
         """
-        assert get_config().get_action_url() == 'foo'
+        assert get_config().get_action_url(None) == 'foo'
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,6 +7,7 @@ from django.test.utils import override_settings
 # We use get_config() instead of adyen_config because throughout
 # the tests, we repeatedly change the Django settings.
 from adyen.config import get_config, AbstractAdyenConfig
+from adyen.settings_config import FromSettingsConfig
 
 
 @override_settings(
@@ -17,12 +18,12 @@ from adyen.config import get_config, AbstractAdyenConfig
 )
 class FromSettingsTestCase(TestCase):
     """
-    This test case tests the FromSettings confic class, which just fetches its
+    This test case tests the FromSettings config class, which just fetches its
     values from the Django settings.
     """
 
     def test_is_default(self):
-        assert 'FromSettingsConfig' in get_config().__class__.__name__
+        assert isinstance(get_config(), FromSettingsConfig)
 
     def test_value_passing_works(self):
         assert get_config().get_action_url(None) == 'foo'
@@ -51,7 +52,7 @@ class CustomConfigClassTestCase(TestCase):
     """
 
     def test_class_gets_picked_up(self):
-        assert 'DummyConfigClass' in get_config().__class__.__name__
+        assert isinstance(get_config(), DummyConfigClass)
 
     @override_settings(ADYEN_ACTION_URL='bar')
     def test_settings_ignored(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,61 @@
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from adyen.config import get_config
+
+
+@override_settings(
+    ADYEN_IDENTIFIER='foo',
+    ADYEN_SECRET_KEY='foo',
+    ADYEN_ACTION_URL='foo',
+    ADYEN_SKIN_CODE='foo',
+)
+class FromSettingsTestCase(TestCase):
+    """
+    This test case tests the FromSettings confic class, which just fetches its
+    values from the Django settings.
+    """
+
+    def test_is_default(self):
+        assert 'FromSettingsConfig' in get_config().__class__.__name__
+
+    def test_value_passing_works(self):
+        assert get_config().get_action_url() == 'foo'
+
+    # https://docs.djangoproject.com/en/1.8/topics/testing/tools/#django.test.modify_settings
+    # Override settings is needed to let us delete settings on a per-test basis.
+    @override_settings()
+    def test_complains_when_not_fully_configured(self):
+        # If the setting is missing, a proper exception is raised
+        del settings.ADYEN_ACTION_URL
+        with self.assertRaises(ImproperlyConfigured):
+            get_config()
+
+
+class DummyConfigClass:
+
+    def get_action_url(self):
+        return 'foo'
+
+
+@override_settings(ADYEN_CONFIG_CLASS='tests.test_config.DummyConfigClass')
+class CustomConfigClassTestCase(TestCase):
+    """
+    This test case checks that it's possible to replace the FromSettings confic class
+    by one's own, and that it is used to fetch values as expected.
+    """
+
+    def test_class_gets_picked_up(self):
+        assert 'DummyConfigClass' in get_config().__class__.__name__
+
+    @override_settings(ADYEN_ACTION_URL='bar')
+    def test_settings_ignored(self):
+        """
+        Check that we indeed ignore Django settings (apart from the config class).
+        """
+        assert get_config().get_action_url() == 'foo'
+
+


### PR DESCRIPTION
The goal of this PR is to allow altering Adyen config values based on the request. That is needed to e.g. switch the identifier if a shop serves different domains.
I couldn't help myself and cleaned up a bit along the way.

This PR does mean interface changes for the Scaffold. Given that suspect this extension gets close to no outside users, I have not made any arrangements for backwards-compatibility. The changes should be easy to implement anyway and are documented.

I accidentally based my PR against master. I'm not sure if it makes much of a difference.