### PR TITLE
Ignore duplicates

### DIFF
--- a/adyen/facade.py
+++ b/adyen/facade.py
@@ -138,7 +138,7 @@ class Facade:
 
                 pass
 
-    def handle_payment_feedback(self, request, record_audit_trail):
+    def handle_payment_feedback(self, request):
         """
         Validate, process, optionally record audit trail and provide feedback
         about the current payment response.
@@ -167,9 +167,8 @@ class Facade:
         success, status, details = response.process()
         txn_details = self._unpack_details(details)
 
-        # ... and record the audit trail if instructed to...
-        if record_audit_trail:
-            self._record_audit_trail(request, status, txn_details)
+        # ... and record the audit trail.
+        self._record_audit_trail(request, status, txn_details)
 
         # ... prepare the feedback data...
         output_data = {

--- a/adyen/scaffold.py
+++ b/adyen/scaffold.py
@@ -83,10 +83,6 @@ class Scaffold:
         return self._normalize_feedback(
             Facade().handle_payment_feedback(request, record_audit_trail=True))
 
-    def check_payment_outcome(self, request):
-        return self._normalize_feedback(
-            Facade().handle_payment_feedback(request, record_audit_trail=False))
-
     def assess_notification_relevance(self, request):
         return Facade().assess_notification_relevance(request)
 

--- a/adyen/scaffold.py
+++ b/adyen/scaffold.py
@@ -80,8 +80,7 @@ class Scaffold:
         return success, common_status, details
 
     def handle_payment_feedback(self, request):
-        return self._normalize_feedback(
-            Facade().handle_payment_feedback(request, record_audit_trail=True))
+        return self._normalize_feedback(Facade().handle_payment_feedback(request))
 
     def assess_notification_relevance(self, request):
         return Facade().assess_notification_relevance(request)

--- a/tests/test_adyen.py
+++ b/tests/test_adyen.py
@@ -421,3 +421,22 @@ class TestAdyenPaymentResponse(AdyenTestCase):
         self.request.POST['eventCode'] = 'REPORT_AVAILABLE'
         must_process, must_ack = self.scaffold.assess_notification_relevance(self.request)
         self.assertTupleEqual((must_process, must_ack), (False, True))
+
+    def test_assert_duplicate_notifications(self):
+        """
+        This test tests that duplicate notifications are ignored.
+        """
+        self.request.method = 'POST'
+        self.request.POST = deepcopy(AUTHORISED_PAYMENT_PARAMS_POST)
+
+        # We have a valid request. So let's confirm that we think we should process
+        # and acknowledge it.
+        assert (True, True) == self.scaffold.assess_notification_relevance(self.request)
+
+        # Let's process it then.
+        __, __, __ = self.scaffold.handle_payment_feedback(self.request)
+
+        # As we have already processed that request, we now shouldn't process the request
+        # any more. But we still acknowledge it.
+        assert (False, True) == self.scaffold.assess_notification_relevance(self.request)
+

--- a/tests/test_adyen.py
+++ b/tests/test_adyen.py
@@ -261,26 +261,6 @@ class TestAdyenPaymentResponse(AdyenTestCase):
 
     def test_handle_authorised_payment(self):
 
-        # Before the test, there are no recorded transactions in the database.
-        num_recorded_transactions = AdyenTransaction.objects.all().count()
-        self.assertEqual(num_recorded_transactions, 0)
-
-        self.request.GET = deepcopy(AUTHORISED_PAYMENT_PARAMS_GET)
-        success, status, details = self.scaffold.check_payment_outcome(self.request)
-
-        self.assertTrue(success)
-        self.assertEqual(status, Scaffold.PAYMENT_STATUS_ACCEPTED)
-        self.assertEqual(details.get('amount'), 13894)
-        self.assertEqual(details.get('ip_address'), '127.0.0.1')
-        self.assertEqual(details.get('method'), 'adyen')
-        self.assertEqual(details.get('psp_reference'), '8814136447235922')
-        self.assertEqual(details.get('status'), 'AUTHORISED')
-
-        # After calling `check_payment_outcome`, there are still no recorded
-        # transactions in the database.
-        num_recorded_transactions = AdyenTransaction.objects.all().count()
-        self.assertEqual(num_recorded_transactions, 0)
-
         self.request.GET = deepcopy(AUTHORISED_PAYMENT_PARAMS_GET)
         success, status, details = self.scaffold.handle_payment_feedback(self.request)
 


### PR DESCRIPTION
This PR does two things. It mirrors changes in the scaffold interface that is done on oshop, by removing `get_payment_outcome`.

Adyen [may duplicate](https://docs.adyen.com/display/TD/Accept+notifications) notifications. The simplification of the scaffold interface means we're confident we're always recording an audit trail, and can rely on that audit trail to ignore duplicated notifications. That's the second part of this PR.