### PR TITLE
Ignore new data coming from Adyen

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,10 @@ See `adyen.settings_config.FromSettingsConfig` for an example.
 Changes
 =======
 
+0.4.1 - unreleased
+------------------
+- ignore additional data sent by Adyen's new-style system communications
+
 0.4.0 - released July 14th, 2015
 --------------------------------
 


### PR DESCRIPTION
When we migrated our Adyen account to the new 'systems communications'
interface, we started getting new data, which caused 500s. As all of it
comes in the `additionalData.KEY = VALUE` format and we don't need it,
we just blanket ignore it for now.