### PR TITLE
Skip Adyen's test notifications

### DIFF
--- a/adyen/facade.py
+++ b/adyen/facade.py
@@ -219,10 +219,17 @@ class Facade:
         if request.POST.get(Constants.EVENT_CODE) != Constants.EVENT_CODE_AUTHORISATION:
             return False, True
 
+        reference = request.POST[Constants.PSP_REFERENCE]
+
+        # Adyen has a notification check that can be run from their control panel.
+        # It's useful to debug connection problems between Adyen and our servers.
+        # So we acknowledge them, but must not process them.
+        if Constants.TEST_REFERENCE_PREFIX in reference:
+            return False, True
+
         # Adyen duplicates many notifications. This bit makes sure we ignore them.
         # "Duplicate notifications have the same corresponding values for their eventCode and
         # pspReference fields."  https://docs.adyen.com/display/TD/Accept+notifications
-        reference = request.POST[Constants.PSP_REFERENCE]
         # The event code gets checked above, so we only need to check for the reference now.
         if AdyenTransaction.objects.filter(reference=reference).exists():
             # We already stored a transaction with this reference, so we can ignore the

--- a/adyen/gateway.py
+++ b/adyen/gateway.py
@@ -53,6 +53,7 @@ class Constants:
     PAYMENT_RESULT_ERROR = 'ERROR'
 
     PSP_REFERENCE = 'pspReference'
+    TEST_REFERENCE_PREFIX = 'test_AUTHORISATION'
     REASON = 'reason'
     RECURRING_CONTRACT = 'recurringContract'
     SECRET_KEY = 'secret_key'
@@ -370,6 +371,10 @@ class PaymentNotification(BaseResponse):
 
 
 class PaymentRedirection(BaseResponse):
+    """
+    Class used to process payment notifications from the user; when they paid on Adyen
+    and get redirected back to our site. HTTP GET from user's browser.
+    """
     REQUIRED_FIELDS = (
         Constants.AUTH_RESULT,
         Constants.MERCHANT_REFERENCE,


### PR DESCRIPTION
Adyen has a notification test that one can trigger from their
control panel. It's useful for debugging connection problems between our
servers and theirs.

This commit adds support for them, in the sense that it doesn't try to
process them. The commit also moves payment notification tests from the
PaymentResponseTestCase, and splits them into individual tests.