### PR TITLE
Cleanup tests, add support for error and pending payment statuses

### DIFF
--- a/adyen/facade.py
+++ b/adyen/facade.py
@@ -11,6 +11,7 @@ from .config import get_config
 
 logger = logging.getLogger('adyen')
 
+
 def get_gateway(request, config):
     return Gateway({
         Constants.IDENTIFIER: config.get_identifier(request),

--- a/adyen/gateway.py
+++ b/adyen/gateway.py
@@ -204,9 +204,9 @@ class BaseInteraction:
                 )
 
 
-# ---[ REQUESTS ]---
+# ---[ FORM-BASED REQUESTS ]---
 
-class BaseRequest(BaseInteraction):
+class FormRequest(BaseInteraction):
     REQUIRED_FIELDS = ()
     OPTIONAL_FIELDS = ()
     HASH_KEYS = ()
@@ -228,11 +228,6 @@ class BaseRequest(BaseInteraction):
 
     def hash(self):
         return self.client._compute_hash(self.HASH_KEYS, self.params)
-
-
-# ---[ FORM-BASED REQUESTS ]---
-
-class FormRequest(BaseRequest):
 
     def build_form_fields(self):
         return [{'type': 'hidden', 'name': name, 'value': value}

--- a/adyen/gateway.py
+++ b/adyen/gateway.py
@@ -383,11 +383,9 @@ class PaymentRedirection(BaseResponse):
         # Check that the transaction has not been tampered with.
         received_hash = self.params.get(self.HASH_FIELD)
         expected_hash = self.hash()
-        if expected_hash != received_hash:
+        if not received_hash or expected_hash != received_hash:
             raise InvalidTransactionException(
-                "The transaction is invalid. "
-                "This may indicate a fraud attempt."
-            )
+                "The transaction is invalid. This may indicate a fraud attempt.")
 
     def process(self):
         payment_result = self.params.get(Constants.AUTH_RESULT, None)

--- a/adyen/gateway.py
+++ b/adyen/gateway.py
@@ -353,7 +353,7 @@ class PaymentNotification(BaseResponse):
         "System communication" setup (instead of the old "notifications" tab
         in the settings).
         We currently don't need any of that data, so we just drop it
-        before validating the response.
+        before validating the notification.
         :return:
         """
         self.params = {

--- a/adyen/gateway.py
+++ b/adyen/gateway.py
@@ -388,6 +388,6 @@ class PaymentRedirection(BaseResponse):
                 "The transaction is invalid. This may indicate a fraud attempt.")
 
     def process(self):
-        payment_result = self.params.get(Constants.AUTH_RESULT, None)
+        payment_result = self.params[Constants.AUTH_RESULT]
         accepted = payment_result == Constants.PAYMENT_RESULT_AUTHORISED
         return accepted, payment_result, self.params

--- a/adyen/scaffold.py
+++ b/adyen/scaffold.py
@@ -13,12 +13,14 @@ class Scaffold:
     PAYMENT_STATUS_ACCEPTED = 'ACCEPTED'
     PAYMENT_STATUS_CANCELLED = 'CANCELLED'
     PAYMENT_STATUS_REFUSED = 'REFUSED'
+    PAYMENT_STATUS_ERROR = 'ERROR'
 
     # This is the mapping between Adyen-specific and these standard statuses
     ADYEN_TO_COMMON_PAYMENT_STATUSES = {
         Constants.PAYMENT_RESULT_AUTHORISED: PAYMENT_STATUS_ACCEPTED,
         Constants.PAYMENT_RESULT_CANCELLED: PAYMENT_STATUS_CANCELLED,
         Constants.PAYMENT_RESULT_REFUSED: PAYMENT_STATUS_REFUSED,
+        Constants.PAYMENT_RESULT_ERROR: PAYMENT_STATUS_ERROR,
     }
 
     def __init__(self):
@@ -76,7 +78,7 @@ class Scaffold:
         common to all payment provider backends.
         """
         success, adyen_status, details = feedback
-        common_status = self.ADYEN_TO_COMMON_PAYMENT_STATUSES.get(adyen_status)
+        common_status = self.ADYEN_TO_COMMON_PAYMENT_STATUSES[adyen_status]
         return success, common_status, details
 
     def handle_payment_feedback(self, request):

--- a/adyen/scaffold.py
+++ b/adyen/scaffold.py
@@ -14,6 +14,7 @@ class Scaffold:
     PAYMENT_STATUS_CANCELLED = 'CANCELLED'
     PAYMENT_STATUS_REFUSED = 'REFUSED'
     PAYMENT_STATUS_ERROR = 'ERROR'
+    PAYMENT_STATUS_PENDING = 'PENDING'
 
     # This is the mapping between Adyen-specific and these standard statuses
     ADYEN_TO_COMMON_PAYMENT_STATUSES = {
@@ -21,6 +22,7 @@ class Scaffold:
         Constants.PAYMENT_RESULT_CANCELLED: PAYMENT_STATUS_CANCELLED,
         Constants.PAYMENT_RESULT_REFUSED: PAYMENT_STATUS_REFUSED,
         Constants.PAYMENT_RESULT_ERROR: PAYMENT_STATUS_ERROR,
+        Constants.PAYMENT_RESULT_PENDING: PAYMENT_STATUS_PENDING,
     }
 
     def __init__(self):

--- a/adyen/scaffold.py
+++ b/adyen/scaffold.py
@@ -10,6 +10,9 @@ class Scaffold:
     # These are the constants that all scaffolds are expected to return
     # to a multi-psp application. They might look like those actually returned
     # by the psp itself, but that would be a pure coincidence.
+    # At some point we could discuss merging cancelled & refused & error and just
+    # ensuring good error messages are returned. I doubt the distinction is
+    # important to most checkout procedures.
     PAYMENT_STATUS_ACCEPTED = 'ACCEPTED'
     PAYMENT_STATUS_CANCELLED = 'CANCELLED'
     PAYMENT_STATUS_REFUSED = 'REFUSED'

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,18 @@
+from copy import deepcopy
+
+
+class MockRequest:
+
+    def __init__(self, data=None, method='GET', remote_address='127.0.0.1'):
+        self.method = method
+        self.META = {}
+
+        if method == 'GET':
+            self.GET = deepcopy(data) or {}
+        elif method == 'POST':
+            self.POST = deepcopy(data) or {}
+
+        # Most tests use unproxied requests, the case of proxied ones
+        # is unit-tested by the `test_get_origin_ip_address` method.
+        if remote_address is not None:
+            self.META['REMOTE_ADDR'] = remote_address

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -21,3 +21,8 @@ MIDDLEWARE_CLASSES = (
 )
 
 INSTALLED_APPS = ('adyen',)
+
+ADYEN_IDENTIFIER = 'OscaroFR'
+ADYEN_SECRET_KEY = 'oscaroscaroscaro'
+ADYEN_ACTION_URL = 'https://test.adyen.com/hpp/select.shtml'
+ADYEN_SKIN_CODE = 'cqQJKZpg'

--- a/tests/test_adyen.py
+++ b/tests/test_adyen.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock
 from django.conf import settings
 from django.test import TestCase
 from django.test.utils import override_settings
+
 from freezegun import freeze_time
 
 from adyen.gateway import MissingFieldException, InvalidTransactionException, PaymentNotification, \
@@ -116,13 +117,12 @@ DUMMY_REQUEST = None
 
 class TestAdyenPaymentRequest(TestCase):
 
-    @override_settings(ADYEN_ACTION_URL=TEST_ACTION_URL)
+    @override_settings(ADYEN_ACTION_URL='foo')
     def test_form_action(self):
         """
         Test that the form action is properly fetched from the settings.
         """
-        action_url = self.scaffold.get_form_action(DUMMY_REQUEST)
-        self.assertEqual(action_url, TEST_ACTION_URL)
+        assert 'foo' == Scaffold().get_form_action(DUMMY_REQUEST)
 
     def test_form_fields_ok(self):
         """
@@ -130,9 +130,11 @@ class TestAdyenPaymentRequest(TestCase):
         """
         with freeze_time(TEST_FROZEN_TIME):
             fields_list = Scaffold().get_form_fields(DUMMY_REQUEST, ORDER_DATA)
-            self.assertEqual(len(fields_list), len(EXPECTED_FIELDS_LIST))
+            # Order doesn't matter, so normally we'd use a set. But Python doesn't do
+            # sets of dictionaries, so we compare individually.
+            assert len(fields_list) == len(EXPECTED_FIELDS_LIST)
             for field in fields_list:
-                self.assertIn(field, EXPECTED_FIELDS_LIST)
+                assert field in EXPECTED_FIELDS_LIST
 
     def test_form_fields_with_missing_mandatory_field(self):
         """

--- a/tests/test_adyen.py
+++ b/tests/test_adyen.py
@@ -1,14 +1,11 @@
 # -*- coding: utf-8 -*-
 
-from copy import deepcopy
-import six
 from unittest.mock import Mock
 
-from django.conf import settings
-from django.test import TestCase
-from django.test.utils import override_settings
+from copy import deepcopy
+import six
 
-from freezegun import freeze_time
+from django.test import TestCase
 
 from adyen.gateway import MissingFieldException, InvalidTransactionException, PaymentNotification, \
     Constants, UnexpectedFieldException
@@ -16,29 +13,7 @@ from adyen.models import AdyenTransaction
 from adyen.scaffold import Scaffold
 from adyen.facade import Facade
 
-
 TEST_IP_ADDRESS_HTTP_HEADER = 'HTTP_X_FORWARDED_FOR'
-
-TEST_RETURN_URL = 'https://www.example.com/checkout/return/adyen/'
-
-TEST_FROZEN_TIME = '2014-07-31 17:00:00'
-
-EXPECTED_FIELDS_LIST = [
-    {'type': 'hidden', 'name': 'currencyCode', 'value': 'EUR'},
-    {'type': 'hidden', 'name': 'merchantAccount', 'value': settings.ADYEN_IDENTIFIER},
-    {'type': 'hidden', 'name': 'merchantReference', 'value': '00000000123'},
-    {'type': 'hidden', 'name': 'merchantReturnData', 'value': 123},
-    {'type': 'hidden', 'name': 'merchantSig', 'value': 'kKvzRvx7wiPLrl8t8+owcmMuJZM='},
-    {'type': 'hidden', 'name': 'paymentAmount', 'value': 123},
-    {'type': 'hidden', 'name': 'resURL', 'value': TEST_RETURN_URL},
-    {'type': 'hidden', 'name': 'sessionValidity', 'value': '2014-07-31T17:20:00Z'},
-    {'type': 'hidden', 'name': 'shipBeforeDate', 'value': '2014-08-30'},
-    {'type': 'hidden', 'name': 'shopperEmail', 'value': 'test@example.com'},
-    {'type': 'hidden', 'name': 'shopperLocale', 'value': 'fr'},
-    {'type': 'hidden', 'name': 'shopperReference', 'value': 789},
-    {'type': 'hidden', 'name': 'skinCode', 'value': 'cqQJKZpg'},
-    {'type': 'hidden', 'name': 'countryCode', 'value': 'fr'},
-]
 
 AUTHORISED_PAYMENT_PARAMS_GET = {
     'authResult': 'AUTHORISED',
@@ -97,55 +72,6 @@ TAMPERED_PAYMENT_PARAMS = {
     'shopperLocale': 'en_GB',
     'skinCode': '4d72uQqA',
 }
-
-ORDER_DATA = {
-    'amount': 123,
-    'basket_id': 456,
-    'client_email': 'test@example.com',
-    'client_id': 789,
-    'currency_code': 'EUR',
-    'country_code': 'fr',
-    'description': 'Order #123',
-    'order_id': 'ORD-123',
-    'order_number': '00000000123',
-    'return_url': TEST_RETURN_URL,
-    'shopper_locale': 'fr',
-}
-
-DUMMY_REQUEST = None
-
-
-class TestAdyenPaymentRequest(TestCase):
-
-    @override_settings(ADYEN_ACTION_URL='foo')
-    def test_form_action(self):
-        """
-        Test that the form action is properly fetched from the settings.
-        """
-        assert 'foo' == Scaffold().get_form_action(DUMMY_REQUEST)
-
-    def test_form_fields_ok(self):
-        """
-        Test that the payment form fields list is properly built.
-        """
-        with freeze_time(TEST_FROZEN_TIME):
-            fields_list = Scaffold().get_form_fields(DUMMY_REQUEST, ORDER_DATA)
-            # Order doesn't matter, so normally we'd use a set. But Python doesn't do
-            # sets of dictionaries, so we compare individually.
-            assert len(fields_list) == len(EXPECTED_FIELDS_LIST)
-            for field in fields_list:
-                assert field in EXPECTED_FIELDS_LIST
-
-    def test_form_fields_with_missing_mandatory_field(self):
-        """
-        Test that the proper exception is raised when trying
-        to build a fields list with a missing mandatory field.
-        """
-        new_order_data = ORDER_DATA.copy()
-        del new_order_data['amount']
-
-        with self.assertRaises(MissingFieldException):
-            Scaffold().get_form_fields(DUMMY_REQUEST, new_order_data)
 
 
 class TestAdyenPaymentResponse(TestCase):

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+
+from unittest.mock import Mock
+
+from copy import deepcopy
+
+from django.test import TestCase
+
+from adyen.gateway import MissingFieldException, PaymentNotification, \
+    Constants, UnexpectedFieldException
+from adyen.scaffold import Scaffold
+
+AUTHORISED_PAYMENT_PARAMS_POST = {
+    'currency': 'EUR',
+    'eventCode': 'AUTHORISATION',
+    'live': 'false',
+    'eventDate': '2014-10-18T17:00:00.00Z',
+    'merchantAccountCode': 'OscaroBE',
+    'merchantReference': '789:456:00000000123',
+    'operations': 'CANCEL,CAPTURE,REFUND',
+    'originalReference': '',
+    'paymentMethod': 'visa',
+    'pspReference': '7914120802434172',
+    'reason': '32853:1111:6/2016',
+    'success': 'true',
+    'value': '21714',
+}
+
+
+class TestAdyenPaymentNotification(TestCase):
+    """
+    Test case that tests Adyen payment notifications (Adyen servers POST'ing to us)
+    """
+
+    def setUp(self):
+        super().setUp()
+        request = Mock()
+        request.method = 'POST'
+        # Most tests use unproxied requests, the case of proxied ones
+        # is unit-tested by the `test_get_origin_ip_address` method.
+        request.META = {'REMOTE_ADDR': '127.0.0.1'}
+        request.POST = deepcopy(AUTHORISED_PAYMENT_PARAMS_POST)
+        self.request = request
+
+    def test_valid_request(self):
+        """
+        If this is an `AUTHORISATION` request targeting the proper platform,
+        we should both process and acknowledge it. This test is needed
+        as a base assumption for the tests below.
+        """
+        assert (True, True) == Scaffold().assess_notification_relevance(self.request)
+
+    def test_platform_mismatch_live_notification(self):
+        """
+        If there is a mismatch between the request origin and target platforms,
+        we should just let it be.
+        """
+        self.request.POST['live'] = 'true'
+        assert (False, False) == Scaffold().assess_notification_relevance(self.request)
+
+    def test_platform_mismatch_live_server(self):
+        self.request.POST['live'] = 'false'
+        with self.settings(ADYEN_ACTION_URL='https://live.adyen.com/hpp/select.shtml'):
+            assert (False, False) == Scaffold().assess_notification_relevance(self.request)
+
+    def test_non_authorisation(self):
+        """
+        If this is not an `AUTHORISATION` request, we should acknowledge it
+        but not try to process it.
+        """
+        self.request.POST[Constants.EVENT_CODE] = 'REPORT_AVAILABLE'
+        assert (False, True) == Scaffold().assess_notification_relevance(self.request)
+
+    def test_duplicate_notifications(self):
+        """
+        This test tests that duplicate notifications are ignored.
+        """
+        # We have a valid request. So let's confirm that we think we should process
+        # and acknowledge it.
+        assert (True, True) == Scaffold().assess_notification_relevance(self.request)
+
+        # Let's process it then.
+        __, __, __ = Scaffold().handle_payment_feedback(self.request)
+
+        # As we have already processed that request, we now shouldn't process the request
+        # any more. But we still acknowledge it.
+        assert (False, True) == Scaffold().assess_notification_relevance(self.request)
+
+    def test_test_notification(self):
+        """
+        Adyen can send test notifications even to the live system for debugging
+        connection problems. We should acknowledge them, but not process.
+        """
+        self.request.POST[Constants.PSP_REFERENCE] = Constants.TEST_REFERENCE_PREFIX + '_5'
+        assert (False, True) == Scaffold().assess_notification_relevance(self.request)
+
+
+class MockClient:
+    secret_key = None
+
+
+class PaymentNotificationTestCase(TestCase):
+
+    def create_mock_notification(self, required=True, optional=False, additional=False):
+        keys_to_set = []
+        if required:
+            keys_to_set += PaymentNotification.REQUIRED_FIELDS
+        if optional:
+            keys_to_set += PaymentNotification.OPTIONAL_FIELDS
+        if additional:
+            keys_to_set += [Constants.ADDITIONAL_DATA_PREFIX + 'foo']
+        params = {key: 'FOO' for key in keys_to_set}
+
+        return PaymentNotification(MockClient(), params)
+
+    def test_required_fields_are_required(self):
+        notification = self.create_mock_notification(
+            required=False, optional=True, additional=True)
+        with self.assertRaises(MissingFieldException):
+            notification.check_fields()
+
+    def test_unknown_fields_cause_exception(self):
+        notification = self.create_mock_notification(
+            required=True, optional=False, additional=False)
+        notification.params['UNKNOWN_FIELD'] = 'foo'
+
+        with self.assertRaises(UnexpectedFieldException):
+            notification.check_fields()
+
+    def test_optional_fields_are_optional(self):
+        notification = self.create_mock_notification(
+            required=True, optional=False, additional=False)
+
+        notification.check_fields()
+
+    def test_additional_fields_are_ignored(self):
+        notification = self.create_mock_notification(
+            required=True, optional=False, additional=True)
+
+        notification.check_fields()

--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -55,9 +55,9 @@ TAMPERED_PAYMENT_PARAMS = {
 TEST_IP_ADDRESS_HTTP_HEADER = 'HTTP_X_FORWARDED_FOR'
 
 
-class TestAdyenPaymentResponse(TestCase):
+class TestAdyenPaymentRedirects(TestCase):
     """
-    Test case that tests Adyen payment responses (user redirected from Adyen to us)
+    Test case that tests Adyen payment redirects (user redirected from Adyen to us)
     """
 
     def setUp(self):

--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -166,3 +166,20 @@ class TestAdyenPaymentRedirects(TestCase):
         assert (not success) and (status == Scaffold.PAYMENT_STATUS_ERROR)
 
         assert AdyenTransaction.objects.filter(status='ERROR').count() == 1
+
+    def test_handle_pending_payment(self):
+        # Modified actual data (see test_handle_error_payment)
+        request = MockRequest({
+            'authResult': 'PENDING',
+            'merchantReference': '09016057',
+            'merchantReturnData': '29232',
+            'merchantSig': 'QTUYO2Bk9CbVCfUztp+MuCFe8do=',
+            'paymentMethod': 'visa',
+            'shopperLocale': 'fr',
+            'skinCode': '4d72uQqA',
+        })
+
+        success, status, __ = Scaffold().handle_payment_feedback(request)
+        assert (not success) and (status == Scaffold.PAYMENT_STATUS_PENDING)
+
+        assert AdyenTransaction.objects.filter(status='PENDING').count() == 1

--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -23,7 +23,11 @@ AUTHORISED_PAYMENT_PARAMS_GET = {
 
 class TestAdyenPaymentRedirects(TestCase):
     """
-    Test case that tests Adyen payment redirects (user redirected from Adyen to us)
+    Test case that tests Adyen payment redirects (user redirected from Adyen to us).
+
+    Note that notifications and redirects are pretty similar and share a lot of
+    common code. So those tests will actually test a lot of code for notifications
+    as well. In an ideal world, we'd split things up to check the shared code individually.
     """
 
     def test_handle_authorised_payment(self):
@@ -129,6 +133,15 @@ class TestAdyenPaymentRedirects(TestCase):
         assert AdyenTransaction.objects.filter(status='REFUSED').count() == 1
 
     def test_signing_is_enforced(self):
+        """
+        Test that the supplied signature (in field merchantSig) is checked and
+        notifications are ignored when the signature doesn't match.
+
+        In an ideal world, our other tests would ignore the signature checking
+        because it's annoying to have to alter the sig when altering the fake
+        data. Maik gets valid signatures by adding a print(expected_hash) to
+        PaymentRedirection.validate.
+        """
         fake_signature = copy(AUTHORISED_PAYMENT_PARAMS_GET)
         fake_signature['merchantSig'] = '14M4N3V1LH4X0RZ'
         signature_none = copy(AUTHORISED_PAYMENT_PARAMS_GET)

--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -1,6 +1,4 @@
-from unittest.mock import Mock
-from copy import deepcopy
-
+from copy import copy
 from django.test import TestCase
 
 from adyen.facade import Facade
@@ -8,8 +6,8 @@ from adyen.gateway import MissingFieldException, InvalidTransactionException
 from adyen.models import AdyenTransaction
 from adyen.scaffold import Scaffold
 
+from tests import MockRequest
 from tests.test_notifications import AUTHORISED_PAYMENT_PARAMS_POST
-
 
 AUTHORISED_PAYMENT_PARAMS_GET = {
     'authResult': 'AUTHORISED',
@@ -22,156 +20,56 @@ AUTHORISED_PAYMENT_PARAMS_GET = {
     'skinCode': '4d72uQqA',
 }
 
-CANCELLED_PAYMENT_PARAMS = {
-    'authResult': 'CANCELLED',
-    'merchantReference': 'WVubjVRFOTPBsLNy33zqliF-vmc:110:00000110',
-    'merchantReturnData': '13894',
-    'merchantSig': 'AMkos00Nn+bTgS3Ndm2bgnRBj1c=',
-    'shopperLocale': 'en_GB',
-    'skinCode': '4d72uQqA',
-}
-
-REFUSED_PAYMENT_PARAMS = {
-    'authResult': 'REFUSED',
-    'merchantReference': 'WVubjVRFOTPBsLNy33zqliF-vmc:110:00000110',
-    'merchantReturnData': '13894',
-    'merchantSig': '1fFM0LaC0uhsN3L/C9nddUeMiyw=',
-    'paymentMethod': 'visa',
-    'pspReference': '8814136452896857',
-    'shopperLocale': 'en_GB',
-    'skinCode': '4d72uQqA',
-}
-
-TAMPERED_PAYMENT_PARAMS = {
-    'authResult': 'AUTHORISED',
-    'merchantReference': 'WVubjVRFOTPBsLNy33zqliF-vmc:109:00000109',
-    'merchantReturnData': '13894',
-    'merchantSig': '14M4N3V1LH4X0RZ',
-    'paymentMethod': 'visa',
-    'pspReference': '8814136447235922',
-    'shopperLocale': 'en_GB',
-    'skinCode': '4d72uQqA',
-}
-TEST_IP_ADDRESS_HTTP_HEADER = 'HTTP_X_FORWARDED_FOR'
-
 
 class TestAdyenPaymentRedirects(TestCase):
     """
     Test case that tests Adyen payment redirects (user redirected from Adyen to us)
     """
 
-    def setUp(self):
-        super().setUp()
-        request = Mock()
-        request.method = 'GET'
-
-        # Most tests use unproxied requests, the case of proxied ones
-        # is unit-tested by the `test_get_origin_ip_address` method.
-        request.META = {
-            'REMOTE_ADDR': '127.0.0.1',
-        }
-
-        self.request = request
-
-    def test_is_valid_ip_address(self):
-        # Valid IPv4 and IPv6 addresses
-        valid_addresses = ['127.0.0.1', '192.168.12.34', '2001:0db8:85a3:0000:0000:8a2e:0370:7334']
-        for address in valid_addresses:
-            assert Facade._is_valid_ip_address(address)
-
-        # Empty string, noise, IPv4 out of range, invalid IPv6-lookalike
-        invalid_addresses = ['', 'TOTORO', '192.168.12.345', '2001::0234:C1ab::A0:aabc:003F']
-        for address in invalid_addresses:
-            assert not Facade._is_valid_ip_address(address)
-
-    def test_get_origin_ip_address(self):
-        """
-        Make sure that the `_get_origin_ip_address()` method works with all
-        the possible meaningful combinations of default and custom HTTP header
-        names.
-        """
-        # With no specified ADYEN_IP_ADDRESS_HTTP_HEADER setting,
-        # ensure we fetch the origin IP address in the REMOTE_ADDR
-        # HTTP header.
-        assert '127.0.0.1' == Facade()._get_origin_ip_address(self.request)
-
-        # Check the return value is None if we have nothing
-        # in the `REMOTE_ADDR` header.
-        self.request.META.update({'REMOTE_ADDR': ''})
-        assert Facade()._get_origin_ip_address(self.request) is None
-
-        # Check the return value is None if we have no `REMOTE_ADDR`
-        # header at all.
-        del self.request.META['REMOTE_ADDR']
-        assert Facade()._get_origin_ip_address(self.request) is None
-
-        with self.settings(ADYEN_IP_ADDRESS_HTTP_HEADER=TEST_IP_ADDRESS_HTTP_HEADER):
-            # Now we add the `HTTP_X_FORWARDED_FOR` header and
-            # ensure it is used instead.
-            self.request.META.update({
-                'REMOTE_ADDR': '127.0.0.1',
-                'HTTP_X_FORWARDED_FOR': '93.16.93.168'
-            })
-            assert '93.16.93.168' == Facade()._get_origin_ip_address(self.request)
-
-            # Even if the default header is missing.
-            del self.request.META['REMOTE_ADDR']
-            assert '93.16.93.168' == Facade()._get_origin_ip_address(self.request)
-
-            # And finally back to `None` if we have neither header.
-            del self.request.META['HTTP_X_FORWARDED_FOR']
-            assert Facade()._get_origin_ip_address(self.request) is None
-
     def test_handle_authorised_payment(self):
-        self.request.GET = deepcopy(AUTHORISED_PAYMENT_PARAMS_GET)
-        success, status, details = Scaffold().handle_payment_feedback(self.request)
+        request = MockRequest(AUTHORISED_PAYMENT_PARAMS_GET)
+        success, status, details = Scaffold().handle_payment_feedback(request)
 
-        self.assertTrue(success)
-        self.assertEqual(status, Scaffold.PAYMENT_STATUS_ACCEPTED)
-        self.assertEqual(details.get('amount'), 13894)
-        self.assertEqual(details.get('ip_address'), '127.0.0.1')
-        self.assertEqual(details.get('method'), 'adyen')
-        self.assertEqual(details.get('psp_reference'), '8814136447235922')
-        self.assertEqual(details.get('status'), 'AUTHORISED')
+        assert success
+        assert status == Scaffold.PAYMENT_STATUS_ACCEPTED
+        assert details['amount'] == 13894
+        assert details['ip_address'] == '127.0.0.1'
+        assert details['method'] == 'adyen'
+        assert details['psp_reference'] == '8814136447235922'
+        assert details['status'] == 'AUTHORISED'
 
         # After calling `handle_payment_feedback` there is one authorised
         # transaction and no refused transaction in the database.
-        num_authorised_transactions = AdyenTransaction.objects.filter(status='AUTHORISED').count()
-        self.assertEqual(num_authorised_transactions, 1)
-        num_refused_transactions = AdyenTransaction.objects.filter(status='REFUSED').count()
-        self.assertEqual(num_refused_transactions, 0)
+        assert AdyenTransaction.objects.filter(status='AUTHORISED').count() == 1
+        assert AdyenTransaction.objects.filter(status='REFUSED').count() == 0
 
         # We delete the previously recorded AdyenTransaction.
         AdyenTransaction.objects.filter(status='AUTHORISED').delete()
 
         # We now test with POST instead of GET.
-        self.request.method = 'POST'
-        self.request.POST = deepcopy(AUTHORISED_PAYMENT_PARAMS_GET)
-        self.request.GET = None
+        request = MockRequest(AUTHORISED_PAYMENT_PARAMS_GET, method='POST')
 
         # This is going to fail because the mandatory fields are not the same
         # for GET and POST requests.
         with self.assertRaises(MissingFieldException):
-            Scaffold().handle_payment_feedback(self.request)
+            Scaffold().handle_payment_feedback(request)
 
         # So, let's try again with valid POST parameters.
-        self.request.POST = deepcopy(AUTHORISED_PAYMENT_PARAMS_POST)
-        success, status, details = Scaffold().handle_payment_feedback(self.request)
+        request = MockRequest(AUTHORISED_PAYMENT_PARAMS_POST, method='POST')
+        success, status, details = Scaffold().handle_payment_feedback(request)
 
-        self.assertTrue(success)
-        self.assertEqual(status, Scaffold.PAYMENT_STATUS_ACCEPTED)
-        self.assertEqual(details.get('amount'), 21714)
-        self.assertEqual(details.get('ip_address'), '127.0.0.1')
-        self.assertEqual(details.get('method'), 'adyen')
-        self.assertEqual(details.get('psp_reference'), '7914120802434172')
-        self.assertEqual(details.get('status'), 'AUTHORISED')
+        assert success
+        assert status == Scaffold.PAYMENT_STATUS_ACCEPTED
+        assert details['amount'] == 21714
+        assert details['ip_address'] == '127.0.0.1'
+        assert details['method'] == 'adyen'
+        assert details['psp_reference'] == '7914120802434172'
+        assert details['status'] == 'AUTHORISED'
 
         # After calling `handle_payment_feedback` there is one authorised
         # transaction and no refused transaction in the database.
-        num_authorised_transactions = AdyenTransaction.objects.filter(status='AUTHORISED').count()
-        self.assertEqual(num_authorised_transactions, 1)
-        num_refused_transactions = AdyenTransaction.objects.filter(status='REFUSED').count()
-        self.assertEqual(num_refused_transactions, 0)
+        assert AdyenTransaction.objects.filter(status='AUTHORISED').count() == 1
+        assert AdyenTransaction.objects.filter(status='REFUSED').count() == 0
 
     def test_handle_authorized_payment_if_no_ip_address_was_found(self):
         """
@@ -179,80 +77,64 @@ class TestAdyenPaymentRedirects(TestCase):
         We just want to ensure that the backend does not crash if we haven't
         been able to find a reliable origin IP address.
         """
-        self.request.GET = deepcopy(AUTHORISED_PAYMENT_PARAMS_GET)
-
-        # Before the test, there are no recorded transactions in the database.
-        num_recorded_transactions = AdyenTransaction.objects.all().count()
-        self.assertEqual(num_recorded_transactions, 0)
-
-        # We alter the request so no IP address will be found...
-        del self.request.META['REMOTE_ADDR']
+        # We create a request so no IP address will be found...
+        request = MockRequest(AUTHORISED_PAYMENT_PARAMS_GET, remote_address=None)
 
         # ... double-check that the IP address is, therefore, `None` ...
-        ip_address = Facade()._get_origin_ip_address(self.request)
-        self.assertIsNone(ip_address)
+        assert Facade()._get_origin_ip_address(request) is None
 
         # ... and finally make sure everything works as expected.
-        success, status, details = Scaffold().handle_payment_feedback(self.request)
+        success, status, details = Scaffold().handle_payment_feedback(request)
 
-        self.assertTrue(success)
-        self.assertEqual(status, Scaffold.PAYMENT_STATUS_ACCEPTED)
-        self.assertEqual(details.get('amount'), 13894)
-        self.assertEqual(details.get('method'), 'adyen')
-        self.assertEqual(details.get('psp_reference'), '8814136447235922')
-        self.assertEqual(details.get('status'), 'AUTHORISED')
-        self.assertIsNone(details.get('ip_address'))
+        assert success
+        assert details['ip_address'] is None
 
         # After the test there's one authorised transaction and no refused transaction in the DB.
-        num_authorised_transactions = AdyenTransaction.objects.filter(status='AUTHORISED').count()
-        self.assertEqual(num_authorised_transactions, 1)
-        num_refused_transactions = AdyenTransaction.objects.filter(status='REFUSED').count()
-        self.assertEqual(num_refused_transactions, 0)
+        assert AdyenTransaction.objects.filter(status='AUTHORISED').count() == 1
+        assert AdyenTransaction.objects.filter(status='REFUSED').count() == 0
 
     def test_handle_cancelled_payment(self):
-
-        # Before the test, there are no recorded transactions in the database.
-        num_recorded_transactions = AdyenTransaction.objects.all().count()
-        self.assertEqual(num_recorded_transactions, 0)
-
-        self.request.GET = deepcopy(CANCELLED_PAYMENT_PARAMS)
-        success, status, __ = Scaffold().handle_payment_feedback(self.request)
-        self.assertFalse(success)
-        self.assertEqual(status, Scaffold.PAYMENT_STATUS_CANCELLED)
+        request = MockRequest({
+            'authResult': 'CANCELLED',
+            'merchantReference': 'WVubjVRFOTPBsLNy33zqliF-vmc:110:00000110',
+            'merchantReturnData': '13894',
+            'merchantSig': 'AMkos00Nn+bTgS3Ndm2bgnRBj1c=',
+            'shopperLocale': 'en_GB',
+            'skinCode': '4d72uQqA',
+        })
+        success, status, __ = Scaffold().handle_payment_feedback(request)
+        assert (not success) and (status == Scaffold.PAYMENT_STATUS_CANCELLED)
 
         # After the test there's one cancelled transaction and no authorised transaction in the DB.
-        num_authorised_transactions = AdyenTransaction.objects.filter(status='AUTHORISED').count()
-        self.assertEqual(num_authorised_transactions, 0)
-        num_cancelled_transactions = AdyenTransaction.objects.filter(status='CANCELLED').count()
-        self.assertEqual(num_cancelled_transactions, 1)
+        assert AdyenTransaction.objects.filter(status='AUTHORISED').count() == 0
+        assert AdyenTransaction.objects.filter(status='CANCELLED').count() == 1
 
     def test_handle_refused_payment(self):
+        request = MockRequest({
+            'authResult': 'REFUSED',
+            'merchantReference': 'WVubjVRFOTPBsLNy33zqliF-vmc:110:00000110',
+            'merchantReturnData': '13894',
+            'merchantSig': '1fFM0LaC0uhsN3L/C9nddUeMiyw=',
+            'paymentMethod': 'visa',
+            'pspReference': '8814136452896857',
+            'shopperLocale': 'en_GB',
+            'skinCode': '4d72uQqA',
+        })
 
-        # Before the test, there are no recorded transactions in the database.
-        num_recorded_transactions = AdyenTransaction.objects.all().count()
-        self.assertEqual(num_recorded_transactions, 0)
-
-        self.request.GET = deepcopy(REFUSED_PAYMENT_PARAMS)
-        success, status, __ = Scaffold().handle_payment_feedback(self.request)
-        self.assertFalse(success)
-        self.assertEqual(status, Scaffold.PAYMENT_STATUS_REFUSED)
+        success, status, __ = Scaffold().handle_payment_feedback(request)
+        assert (not success) and (status == Scaffold.PAYMENT_STATUS_REFUSED)
 
         # After the test there's one refused transaction and no authorised transaction in the DB.
-        num_authorised_transactions = AdyenTransaction.objects.filter(status='AUTHORISED').count()
-        self.assertEqual(num_authorised_transactions, 0)
-        num_refused_transactions = AdyenTransaction.objects.filter(status='REFUSED').count()
-        self.assertEqual(num_refused_transactions, 1)
+        assert AdyenTransaction.objects.filter(status='AUTHORISED').count() == 0
+        assert AdyenTransaction.objects.filter(status='REFUSED').count() == 1
 
     def test_handle_tampered_payment(self):
+        tampered_data = copy(AUTHORISED_PAYMENT_PARAMS_GET)
+        tampered_data['merchantSig'] = '14M4N3V1LH4X0RZ'
+        request = MockRequest(tampered_data)
 
-        # Before the test, there are no recorded transactions in the database.
-        num_recorded_transactions = AdyenTransaction.objects.all().count()
-        self.assertEqual(num_recorded_transactions, 0)
-
-        self.request.GET = deepcopy(TAMPERED_PAYMENT_PARAMS)
         with self.assertRaises(InvalidTransactionException):
-            Scaffold().handle_payment_feedback(self.request)
+            Scaffold().handle_payment_feedback(request)
 
         # After the test, there are still no recorded transactions in the database.
-        num_recorded_transactions = AdyenTransaction.objects.all().count()
-        self.assertEqual(num_recorded_transactions, 0)
+        assert not AdyenTransaction.objects.exists()

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1,0 +1,74 @@
+from django.conf import settings
+from django.test import TestCase, override_settings
+
+from freezegun import freeze_time
+
+from adyen.gateway import MissingFieldException
+from adyen.scaffold import Scaffold
+
+
+TEST_RETURN_URL = 'https://www.example.com/checkout/return/adyen/'
+
+EXPECTED_FIELDS_LIST = [
+    {'type': 'hidden', 'name': 'currencyCode', 'value': 'EUR'},
+    {'type': 'hidden', 'name': 'merchantAccount', 'value': settings.ADYEN_IDENTIFIER},
+    {'type': 'hidden', 'name': 'merchantReference', 'value': '00000000123'},
+    {'type': 'hidden', 'name': 'merchantReturnData', 'value': 123},
+    {'type': 'hidden', 'name': 'merchantSig', 'value': 'kKvzRvx7wiPLrl8t8+owcmMuJZM='},
+    {'type': 'hidden', 'name': 'paymentAmount', 'value': 123},
+    {'type': 'hidden', 'name': 'resURL', 'value': TEST_RETURN_URL},
+    {'type': 'hidden', 'name': 'sessionValidity', 'value': '2014-07-31T17:20:00Z'},
+    {'type': 'hidden', 'name': 'shipBeforeDate', 'value': '2014-08-30'},
+    {'type': 'hidden', 'name': 'shopperEmail', 'value': 'test@example.com'},
+    {'type': 'hidden', 'name': 'shopperLocale', 'value': 'fr'},
+    {'type': 'hidden', 'name': 'shopperReference', 'value': 789},
+    {'type': 'hidden', 'name': 'skinCode', 'value': 'cqQJKZpg'},
+    {'type': 'hidden', 'name': 'countryCode', 'value': 'fr'},
+]
+
+ORDER_DATA = {
+    'amount': 123,
+    'basket_id': 456,
+    'client_email': 'test@example.com',
+    'client_id': 789,
+    'currency_code': 'EUR',
+    'country_code': 'fr',
+    'description': 'Order #123',
+    'order_id': 'ORD-123',
+    'order_number': '00000000123',
+    'return_url': TEST_RETURN_URL,
+    'shopper_locale': 'fr',
+}
+
+
+class TestAdyenPaymentRequest(TestCase):
+
+    @override_settings(ADYEN_ACTION_URL='foo')
+    def test_form_action(self):
+        """
+        Test that the form action is properly fetched from the settings.
+        """
+        assert 'foo' == Scaffold().get_form_action(request=None)
+
+    def test_form_fields_ok(self):
+        """
+        Test that the payment form fields list is properly built.
+        """
+        with freeze_time('2014-07-31 17:00:00'):  # Any datetime will do.
+            fields_list = Scaffold().get_form_fields(request=None, order_data=ORDER_DATA)
+            # Order doesn't matter, so normally we'd use a set. But Python doesn't do
+            # sets of dictionaries, so we compare individually.
+            assert len(fields_list) == len(EXPECTED_FIELDS_LIST)
+            for field in fields_list:
+                assert field in EXPECTED_FIELDS_LIST
+
+    def test_form_fields_with_missing_mandatory_field(self):
+        """
+        Test that the proper exception is raised when trying
+        to build a fields list with a missing mandatory field.
+        """
+        new_order_data = ORDER_DATA.copy()
+        del new_order_data['amount']
+
+        with self.assertRaises(MissingFieldException):
+            Scaffold().get_form_fields(request=None, order_data=new_order_data)

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -1,19 +1,16 @@
-# -*- coding: utf-8 -*-
-
 from unittest.mock import Mock
-
 from copy import deepcopy
-import six
 
 from django.test import TestCase
 
-from adyen.gateway import MissingFieldException, InvalidTransactionException, PaymentNotification, \
-    Constants, UnexpectedFieldException
+import six
+
+from adyen.facade import Facade
+from adyen.gateway import MissingFieldException, InvalidTransactionException
 from adyen.models import AdyenTransaction
 from adyen.scaffold import Scaffold
-from adyen.facade import Facade
 
-TEST_IP_ADDRESS_HTTP_HEADER = 'HTTP_X_FORWARDED_FOR'
+from tests.test_notifications import AUTHORISED_PAYMENT_PARAMS_POST
 
 AUTHORISED_PAYMENT_PARAMS_GET = {
     'authResult': 'AUTHORISED',
@@ -24,22 +21,6 @@ AUTHORISED_PAYMENT_PARAMS_GET = {
     'pspReference': '8814136447235922',
     'shopperLocale': 'en_GB',
     'skinCode': '4d72uQqA',
-}
-
-AUTHORISED_PAYMENT_PARAMS_POST = {
-    'currency': 'EUR',
-    'eventCode': 'AUTHORISATION',
-    'live': 'false',
-    'eventDate': '2014-10-18T17:00:00.00Z',
-    'merchantAccountCode': 'OscaroBE',
-    'merchantReference': '789:456:00000000123',
-    'operations': 'CANCEL,CAPTURE,REFUND',
-    'originalReference': '',
-    'paymentMethod': 'visa',
-    'pspReference': '7914120802434172',
-    'reason': '32853:1111:6/2016',
-    'success': 'true',
-    'value': '21714',
 }
 
 CANCELLED_PAYMENT_PARAMS = {
@@ -72,6 +53,7 @@ TAMPERED_PAYMENT_PARAMS = {
     'shopperLocale': 'en_GB',
     'skinCode': '4d72uQqA',
 }
+TEST_IP_ADDRESS_HTTP_HEADER = 'HTTP_X_FORWARDED_FOR'
 
 
 class TestAdyenPaymentResponse(TestCase):
@@ -309,116 +291,3 @@ class TestAdyenPaymentResponse(TestCase):
         # After the test, there are still no recorded transactions in the database.
         num_recorded_transactions = AdyenTransaction.objects.all().count()
         self.assertEqual(num_recorded_transactions, 0)
-
-
-class TestAdyenPaymentNotification(TestCase):
-    """
-    Test case that tests Adyen payment notifications (Adyen servers POST'ing to us)
-    """
-
-    def setUp(self):
-        super().setUp()
-        request = Mock()
-        request.method = 'POST'
-        # Most tests use unproxied requests, the case of proxied ones
-        # is unit-tested by the `test_get_origin_ip_address` method.
-        request.META = {'REMOTE_ADDR': '127.0.0.1'}
-        request.POST = deepcopy(AUTHORISED_PAYMENT_PARAMS_POST)
-        self.request = request
-
-    def test_valid_request(self):
-        """
-        If this is an `AUTHORISATION` request targeting the proper platform,
-        we should both process and acknowledge it. This test is needed
-        as a base assumption for the tests below.
-        """
-        assert (True, True) == Scaffold().assess_notification_relevance(self.request)
-
-    def test_platform_mismatch_live_notification(self):
-        """
-        If there is a mismatch between the request origin and target platforms,
-        we should just let it be.
-        """
-        self.request.POST['live'] = 'true'
-        assert (False, False) == Scaffold().assess_notification_relevance(self.request)
-
-    def test_platform_mismatch_live_server(self):
-        self.request.POST['live'] = 'false'
-        with self.settings(ADYEN_ACTION_URL='https://live.adyen.com/hpp/select.shtml'):
-            assert (False, False) == Scaffold().assess_notification_relevance(self.request)
-
-    def test_non_authorisation(self):
-        """
-        If this is not an `AUTHORISATION` request, we should acknowledge it
-        but not try to process it.
-        """
-        self.request.POST[Constants.EVENT_CODE] = 'REPORT_AVAILABLE'
-        assert (False, True) == Scaffold().assess_notification_relevance(self.request)
-
-    def test_duplicate_notifications(self):
-        """
-        This test tests that duplicate notifications are ignored.
-        """
-        # We have a valid request. So let's confirm that we think we should process
-        # and acknowledge it.
-        assert (True, True) == Scaffold().assess_notification_relevance(self.request)
-
-        # Let's process it then.
-        __, __, __ = Scaffold().handle_payment_feedback(self.request)
-
-        # As we have already processed that request, we now shouldn't process the request
-        # any more. But we still acknowledge it.
-        assert (False, True) == Scaffold().assess_notification_relevance(self.request)
-
-    def test_test_notification(self):
-        """
-        Adyen can send test notifications even to the live system for debugging
-        connection problems. We should acknowledge them, but not process.
-        """
-        self.request.POST[Constants.PSP_REFERENCE] = Constants.TEST_REFERENCE_PREFIX + '_5'
-        assert (False, True) == Scaffold().assess_notification_relevance(self.request)
-
-
-class MockClient:
-    secret_key = None
-
-
-class PaymentNotificationTestCase(TestCase):
-
-    def create_mock_notification(self, required=True, optional=False, additional=False):
-        keys_to_set = []
-        if required:
-            keys_to_set += PaymentNotification.REQUIRED_FIELDS
-        if optional:
-            keys_to_set += PaymentNotification.OPTIONAL_FIELDS
-        if additional:
-            keys_to_set += [Constants.ADDITIONAL_DATA_PREFIX + 'foo']
-        params = {key: 'FOO' for key in keys_to_set}
-
-        return PaymentNotification(MockClient(), params)
-
-    def test_required_fields_are_required(self):
-        notification = self.create_mock_notification(
-            required=False, optional=True, additional=True)
-        with self.assertRaises(MissingFieldException):
-            notification.check_fields()
-
-    def test_unknown_fields_cause_exception(self):
-        notification = self.create_mock_notification(
-            required=True, optional=False, additional=False)
-        notification.params['UNKNOWN_FIELD'] = 'foo'
-
-        with self.assertRaises(UnexpectedFieldException):
-            notification.check_fields()
-
-    def test_optional_fields_are_optional(self):
-        notification = self.create_mock_notification(
-            required=True, optional=False, additional=False)
-
-        notification.check_fields()
-
-    def test_additional_fields_are_ignored(self):
-        notification = self.create_mock_notification(
-            required=True, optional=False, additional=True)
-
-        notification.check_fields()

--- a/tests/test_unit_tests.py
+++ b/tests/test_unit_tests.py
@@ -1,0 +1,104 @@
+from django.test import override_settings, TestCase
+from adyen.facade import Facade
+from adyen.gateway import PaymentNotification, Constants, MissingFieldException, \
+    UnexpectedFieldException
+from tests import MockRequest
+
+
+def test_is_valid_ip_address():
+    # Valid IPv4 and IPv6 addresses
+    valid_addresses = ['127.0.0.1', '192.168.12.34', '2001:0db8:85a3:0000:0000:8a2e:0370:7334']
+    for address in valid_addresses:
+        assert Facade._is_valid_ip_address(address)
+
+    # Empty string, noise, IPv4 out of range, invalid IPv6-lookalike
+    invalid_addresses = ['', 'TOTORO', '192.168.12.345', '2001::0234:C1ab::A0:aabc:003F']
+    for address in invalid_addresses:
+        assert not Facade._is_valid_ip_address(address)
+
+
+TEST_IP_ADDRESS_HTTP_HEADER = 'HTTP_X_FORWARDED_FOR'
+
+
+def test_get_origin_ip_address():
+    """
+    Make sure that the `_get_origin_ip_address()` method works with all
+    the possible meaningful combinations of default and custom HTTP header
+    names.
+    """
+    get_ip_address = Facade()._get_origin_ip_address
+    # With no specified ADYEN_IP_ADDRESS_HTTP_HEADER setting,
+    # ensure we fetch the origin IP address in the REMOTE_ADDR
+    # HTTP header.
+    assert '127.0.0.1' == get_ip_address(MockRequest())
+
+    # Check the return value is None if we have nothing
+    # in the `REMOTE_ADDR` header.
+    assert get_ip_address(MockRequest(remote_address='')) is None
+
+    # Check the return value is None if we have no `REMOTE_ADDR`
+    # header at all.
+    assert get_ip_address(MockRequest(remote_address=None)) is None
+
+    with override_settings(ADYEN_IP_ADDRESS_HTTP_HEADER=TEST_IP_ADDRESS_HTTP_HEADER):
+        # Now we add the `HTTP_X_FORWARDED_FOR` header and
+        # ensure it is used instead.
+        request = MockRequest()
+        request.META.update({
+            'REMOTE_ADDR': '127.0.0.1',
+            'HTTP_X_FORWARDED_FOR': '93.16.93.168'
+        })
+        assert '93.16.93.168' == get_ip_address(request)
+
+        # Even if the default header is missing.
+        del request.META['REMOTE_ADDR']
+        assert '93.16.93.168' == Facade()._get_origin_ip_address(request)
+
+        # And finally back to `None` if we have neither header.
+        del request.META['HTTP_X_FORWARDED_FOR']
+        assert Facade()._get_origin_ip_address(request) is None
+
+
+class MockClient:
+    secret_key = None
+
+
+class PaymentNotificationTestCase(TestCase):
+
+    def create_mock_notification(self, required=True, optional=False, additional=False):
+        keys_to_set = []
+        if required:
+            keys_to_set += PaymentNotification.REQUIRED_FIELDS
+        if optional:
+            keys_to_set += PaymentNotification.OPTIONAL_FIELDS
+        if additional:
+            keys_to_set += [Constants.ADDITIONAL_DATA_PREFIX + 'foo']
+        params = {key: 'FOO' for key in keys_to_set}
+
+        return PaymentNotification(MockClient(), params)
+
+    def test_required_fields_are_required(self):
+        notification = self.create_mock_notification(
+            required=False, optional=True, additional=True)
+        with self.assertRaises(MissingFieldException):
+            notification.check_fields()
+
+    def test_unknown_fields_cause_exception(self):
+        notification = self.create_mock_notification(
+            required=True, optional=False, additional=False)
+        notification.params['UNKNOWN_FIELD'] = 'foo'
+
+        with self.assertRaises(UnexpectedFieldException):
+            notification.check_fields()
+
+    def test_optional_fields_are_optional(self):
+        notification = self.create_mock_notification(
+            required=True, optional=False, additional=False)
+
+        notification.check_fields()
+
+    def test_additional_fields_are_ignored(self):
+        notification = self.create_mock_notification(
+            required=True, optional=False, additional=True)
+
+        notification.check_fields()


### PR DESCRIPTION
We ran into a bug where a payment status of `ERROR` was not handled by `django-oscar-adyen`, and we realized that a payment status of `PENDING` also isn't supported. To properly test for this, I went on a bit of a rampage to first clean up tests and a bit of actual code. The only "real" changes should be the two "Handle XX status notifications from Adyen" commits. 

Reviewing commit by commit is recommended.