### PR TITLE
Allow client code to use the Adyen merchantReturnData field.

### DIFF
--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -13,7 +13,7 @@ EXPECTED_FIELDS_LIST = [
     {'type': 'hidden', 'name': 'currencyCode', 'value': 'EUR'},
     {'type': 'hidden', 'name': 'merchantAccount', 'value': settings.ADYEN_IDENTIFIER},
     {'type': 'hidden', 'name': 'merchantReference', 'value': '00000000123'},
-    {'type': 'hidden', 'name': 'merchantReturnData', 'value': 123},
+    {'type': 'hidden', 'name': 'merchantReturnData', 'value': '123'},
     {'type': 'hidden', 'name': 'merchantSig', 'value': 'kKvzRvx7wiPLrl8t8+owcmMuJZM='},
     {'type': 'hidden', 'name': 'paymentAmount', 'value': 123},
     {'type': 'hidden', 'name': 'resURL', 'value': TEST_RETURN_URL},


### PR DESCRIPTION
The `merchantReturnData` field was blocked for use in client code, as the module used it for its own purpose in storing the transaction amount value (see the TODO at `facade.py:85`). This PR allows client code to also use this field by providing a `merchant_return_data` value in the order details, while preserving the internal use.

If any client data is provided for this field, it is appended to the amount value (now converted to a string) and separated by a tilde (~) character, which is valid in a URL without encoding, and highly unlikely to appear in any client data (e.g. it normally wouldn't appear in a Django session ID, which is what I need it for, and also what Adyen says is the typical usage for the field). Any provided data is first encoded as UTF-8 and then urlencoded for safe transmission as a URL param.

During the postback detail unpacking, the `merchantReturnData` field is split on the tilde character (if it is present), and the decoded data is returned to the client code as `details['merchant_return_data']`.