### PR TITLE
Config signers

### DIFF
--- a/adyen/config.py
+++ b/adyen/config.py
@@ -65,6 +65,18 @@ class AbstractAdyenConfig:
         """
         raise NotImplementedError
 
+    def get_signer_backend(self, request):
+        """Get the signer backend class as a python path.
+
+        :param request: Django HTTP request object.
+        :return: The python path to the signer backend class to use.
+        :rtype: str
+
+        The signer object will be used to sign payment request form and to
+        verify Adyen payment result fields and/or notifications.
+        """
+        raise NotImplementedError
+
     def get_ip_address_header(self):
         """Get the request HTTP header used to get customer's IP.
 

--- a/adyen/constants.py
+++ b/adyen/constants.py
@@ -1,0 +1,65 @@
+
+
+class Constants:
+    """List of all constants."""
+    ACCEPTED_NOTIFICATION = '[accepted]'
+
+    ACTION_URL = 'action_url'
+    ADYEN = 'adyen'
+    ALLOWED_METHODS = 'allowedMethods'
+    AUTH_RESULT = 'authResult'
+    BILLING_ADDRESS_TYPE = 'billingAddressType'
+    BLOCKED_METHODS = 'blockedMethods'
+    COUNTRY_CODE = 'countryCode'
+    CURRENCY = 'currency'
+    CURRENCY_CODE = 'currencyCode'
+    DELIVERY_ADDRESS_TYPE = 'deliveryAddressType'
+
+    EVENT_CODE = 'eventCode'
+    EVENT_CODE_AUTHORISATION = 'AUTHORISATION'
+    EVENT_DATE = 'eventDate'
+
+    FALSE = 'false'
+    IDENTIFIER = 'identifier'
+    LIVE = 'live'
+
+    MERCHANT_ACCOUNT = 'merchantAccount'
+    MERCHANT_ACCOUNT_CODE = 'merchantAccountCode'
+    MERCHANT_REFERENCE = 'merchantReference'
+    MERCHANT_RETURN_DATA = 'merchantReturnData'
+    MERCHANT_RETURN_URL = 'resURL'
+    MERCHANT_SIG = 'merchantSig'
+
+    OFFSET = 'offset'
+    OPERATIONS = 'operations'
+    ORIGINAL_REFERENCE = 'originalReference'
+
+    PAYMENT_AMOUNT = 'paymentAmount'
+    PAYMENT_METHOD = 'paymentMethod'
+    PAYMENT_RESULT_AUTHORISED = 'AUTHORISED'
+    PAYMENT_RESULT_REFUSED = 'REFUSED'
+    PAYMENT_RESULT_CANCELLED = 'CANCELLED'
+    PAYMENT_RESULT_PENDING = 'PENDING'
+    PAYMENT_RESULT_ERROR = 'ERROR'
+
+    PSP_REFERENCE = 'pspReference'
+    TEST_REFERENCE_PREFIX = 'test_AUTHORISATION'
+    REASON = 'reason'
+    RECURRING_CONTRACT = 'recurringContract'
+    SECRET_KEY = 'secret_key'
+    SEPARATOR = ':'
+    SESSION_VALIDITY = 'sessionValidity'
+    SKIN_CODE = 'skinCode'
+    SHIP_BEFORE_DATE = 'shipBeforeDate'
+    ADDITIONAL_DATA_PREFIX = 'additionalData.'
+
+    SHOPPER_EMAIL = 'shopperEmail'
+    SHOPPER_LOCALE = 'shopperLocale'
+    SHOPPER_REFERENCE = 'shopperReference'
+    SHOPPER_STATEMENT = 'shopperStatement'
+    SHOPPER_TYPE = 'shopperType'
+
+    SUCCESS = 'success'
+    TEST = 'test'
+    TRUE = 'true'
+    VALUE = 'value'

--- a/adyen/constants.py
+++ b/adyen/constants.py
@@ -21,6 +21,8 @@ class Constants:
 
     FALSE = 'false'
     IDENTIFIER = 'identifier'
+    SECRET_KEY = 'secret_key'
+    SIGNER = 'signer'
     LIVE = 'live'
 
     MERCHANT_ACCOUNT = 'merchantAccount'
@@ -46,7 +48,6 @@ class Constants:
     TEST_REFERENCE_PREFIX = 'test_AUTHORISATION'
     REASON = 'reason'
     RECURRING_CONTRACT = 'recurringContract'
-    SECRET_KEY = 'secret_key'
     SEPARATOR = ':'
     SESSION_VALIDITY = 'sessionValidity'
     SKIN_CODE = 'skinCode'

--- a/adyen/exceptions.py
+++ b/adyen/exceptions.py
@@ -1,0 +1,17 @@
+"""Adyen custom exceptions."""
+
+
+class MissingParameterException(ValueError):
+    pass
+
+
+class MissingFieldException(ValueError):
+    pass
+
+
+class UnexpectedFieldException(ValueError):
+    pass
+
+
+class InvalidTransactionException(ValueError):
+    pass

--- a/adyen/facade.py
+++ b/adyen/facade.py
@@ -4,6 +4,7 @@ import logging
 
 import iptools
 from django.http import HttpResponse
+from django.utils.module_loading import import_string
 from oscar.core.loading import get_class
 
 from .config import get_config
@@ -34,10 +35,13 @@ def get_gateway(request, config):
     based on the country or the language (or even the type of customer, its
     IP address, or other request specific parameter).
     """
+    signer_class = import_string(config.get_signer_backend(request))
+    secret_key = config.get_skin_secret(request)
     return Gateway({
         Constants.IDENTIFIER: config.get_identifier(request),
-        Constants.SECRET_KEY: config.get_skin_secret(request),
+        Constants.SECRET_KEY: secret_key,
         Constants.ACTION_URL: config.get_action_url(request),
+        Constants.SIGNER: signer_class(secret_key),
     })
 
 

--- a/adyen/gateway.py
+++ b/adyen/gateway.py
@@ -1,96 +1,17 @@
-# -*- coding: utf-8 -*-
-
 import base64
 import hashlib
 import hmac
 import logging
 
+from .constants import Constants
+from .exceptions import (
+    InvalidTransactionException,
+    MissingFieldException,
+    MissingParameterException,
+    UnexpectedFieldException,
+)
+
 logger = logging.getLogger('adyen')
-
-
-# ---[ CONSTANTS ]---
-
-class Constants:
-
-    ACCEPTED_NOTIFICATION = '[accepted]'
-
-    ACTION_URL = 'action_url'
-    ADYEN = 'adyen'
-    ALLOWED_METHODS = 'allowedMethods'
-    AUTH_RESULT = 'authResult'
-    BILLING_ADDRESS_TYPE = 'billingAddressType'
-    BLOCKED_METHODS = 'blockedMethods'
-    COUNTRY_CODE = 'countryCode'
-    CURRENCY = 'currency'
-    CURRENCY_CODE = 'currencyCode'
-    DELIVERY_ADDRESS_TYPE = 'deliveryAddressType'
-
-    EVENT_CODE = 'eventCode'
-    EVENT_CODE_AUTHORISATION = 'AUTHORISATION'
-    EVENT_DATE = 'eventDate'
-
-    FALSE = 'false'
-    IDENTIFIER = 'identifier'
-    LIVE = 'live'
-
-    MERCHANT_ACCOUNT = 'merchantAccount'
-    MERCHANT_ACCOUNT_CODE = 'merchantAccountCode'
-    MERCHANT_REFERENCE = 'merchantReference'
-    MERCHANT_RETURN_DATA = 'merchantReturnData'
-    MERCHANT_RETURN_URL = 'resURL'
-    MERCHANT_SIG = 'merchantSig'
-
-    OFFSET = 'offset'
-    OPERATIONS = 'operations'
-    ORIGINAL_REFERENCE = 'originalReference'
-
-    PAYMENT_AMOUNT = 'paymentAmount'
-    PAYMENT_METHOD = 'paymentMethod'
-    PAYMENT_RESULT_AUTHORISED = 'AUTHORISED'
-    PAYMENT_RESULT_REFUSED = 'REFUSED'
-    PAYMENT_RESULT_CANCELLED = 'CANCELLED'
-    PAYMENT_RESULT_PENDING = 'PENDING'
-    PAYMENT_RESULT_ERROR = 'ERROR'
-
-    PSP_REFERENCE = 'pspReference'
-    TEST_REFERENCE_PREFIX = 'test_AUTHORISATION'
-    REASON = 'reason'
-    RECURRING_CONTRACT = 'recurringContract'
-    SECRET_KEY = 'secret_key'
-    SEPARATOR = ':'
-    SESSION_VALIDITY = 'sessionValidity'
-    SKIN_CODE = 'skinCode'
-    SHIP_BEFORE_DATE = 'shipBeforeDate'
-    ADDITIONAL_DATA_PREFIX = 'additionalData.'
-
-    SHOPPER_EMAIL = 'shopperEmail'
-    SHOPPER_LOCALE = 'shopperLocale'
-    SHOPPER_REFERENCE = 'shopperReference'
-    SHOPPER_STATEMENT = 'shopperStatement'
-    SHOPPER_TYPE = 'shopperType'
-
-    SUCCESS = 'success'
-    TEST = 'test'
-    TRUE = 'true'
-    VALUE = 'value'
-
-
-# ---[ EXCEPTIONS ]---
-
-class MissingParameterException(ValueError):
-    pass
-
-
-class MissingFieldException(ValueError):
-    pass
-
-
-class UnexpectedFieldException(ValueError):
-    pass
-
-
-class InvalidTransactionException(ValueError):
-    pass
 
 
 # ---[ GATEWAY ]---

--- a/adyen/settings_config.py
+++ b/adyen/settings_config.py
@@ -56,6 +56,14 @@ class FromSettingsConfig(AbstractAdyenConfig):
         """Return :data:`ADYEN_SECRET_KEY`."""
         return settings.ADYEN_SECRET_KEY
 
+    def get_signer_backend(self, request):
+        """Return :data:`ADYEN_SIGNER_BACKEND` or ``adyen.signers.HMACSha1``"""
+        try:
+            return settings.ADYEN_SIGNER_BACKEND
+        except AttributeError:
+            # Default to the SHA-1 algorithm
+            return 'adyen.signers.HMACSha1'
+
     def get_ip_address_header(self):
         """Return :data:`ADYEN_IP_ADDRESS_HTTP_HEADER` or ``REMOTE_ADDR``.
 

--- a/adyen/signers.py
+++ b/adyen/signers.py
@@ -1,0 +1,214 @@
+"""Signers are helpers to sign and verify Adyen requests & responses.
+
+There are currently 2 type of signatures:
+
+* SHA-1, deprecated by Adyen but still used,
+* SHA-2 (256), preferred by Adyen.
+
+Each signer follows different rules to sign payment request form, and to verify
+Adyen return response and Adyen notification.
+"""
+import base64
+import hashlib
+import hmac
+
+from adyen.constants import Constants
+
+
+class AbstractSigner:
+    """Abstract base class that define the common interface.
+
+    A signer must expose three methods:
+
+    * :meth:`sign`: take form fields and return a dict of signature fields.
+    * :meth:`verify`: take a dict of fields and make sure there have an
+        appropriate signature field.
+    * :meth:`compute_hash`: take a signature string and compute its hash value.
+
+    These methods are not implementd by the :class:`AbstractSigner`, therefore
+    subclasses **must** implement them.
+    """
+    def __init__(self, secret_key):
+        self.secret_key = secret_key
+        """Adyen Skin secret key
+
+        This secret key is used to sign payment request, and verify payment
+        return response and payment notification.
+        """
+
+    def sign(self, fields):
+        """Sign the given form ``fields`` and return the signature fields.
+
+        :param dict fields: The form fields used to perform a payment request
+        :return: A dict of signature fields
+        :rtype: ``dict``
+
+        A payment request form must contains specific signature fields,
+        depending on the selected sign method.
+        """
+        raise NotImplementedError
+
+    def verify(self, fields):
+        """Verify ``fields`` contains the appropriate signatures.
+
+        :param dict fields: A dict of fields, given by a payment return
+            response or by a payment notification.
+        :return: ``True`` the ``fields`` contain valid signatures
+        :rtype: ``boolean``
+
+        Adyen can secure communication with merchant site using signatures:
+
+        * ``merchantSig`` for the return URL,
+        * ``additionalData.hmacSignature`` for notification,
+
+        And this method can be used for both, provided with all the fields
+        as a flat ``dict``.
+
+        The following example is taken from the Adyen documentation::
+
+            {
+               "live":"false",
+               "notificationItems": [
+                  {
+                     "notificationRequestItem": {
+                        "additionalData": {
+                           "hmacSignature":"SIGN_KEY"
+                        },
+                        "amount": {
+                           "value":1130,
+                           "currency":"EUR"
+                        },
+                        "pspReference":"7914073381342284",
+                        # ... other fields
+                     }
+                  }
+               ]
+            }
+
+        The expected fields will be::
+
+            {
+                'additionalData.hmacSignature': 'SIGN_KEY',
+                'amount.value': 1130,
+                'amount.currency': 'EUR',
+                'pspReference: "7914073381342284"
+                # ... other fields
+            }
+
+        This format correspond to the ``POST`` notification format.
+        """
+        raise NotImplementedError
+
+    def compute_hash(self, signature):
+        """Return a hash for the given ``signature`` string.
+
+        :param str signature: A ``signature`` used to compute hash.
+        :return: A hashed version of the ``signature`` using the
+            :attr:`secret_key` and the defined hash algorithm.
+
+        Each implementation should simply use a different hash algorithm to
+        sign the ``signature`` string. This method is not supposed to know how
+        the ``signature`` string is built.
+        """
+        raise NotImplementedError
+
+
+class HMACSha1(AbstractSigner):
+    """Implement a HMAC signature with SHA-1 algorithm.
+
+    .. seealso::
+
+        The Adyen documentation about `SHA-1 deprecated method`__.
+
+        .. __: https://docs.adyen.com/manuals/hpp-manual#hmacpaymentsetupsha1deprecated
+
+    """
+    PAYMENT_FORM_HASH_KEYS = (
+        Constants.PAYMENT_AMOUNT,
+        Constants.CURRENCY_CODE,
+        Constants.SHIP_BEFORE_DATE,
+        Constants.MERCHANT_REFERENCE,
+        Constants.SKIN_CODE,
+        Constants.MERCHANT_ACCOUNT,
+        Constants.SESSION_VALIDITY,
+        Constants.SHOPPER_EMAIL,
+        Constants.SHOPPER_REFERENCE,
+        Constants.RECURRING_CONTRACT,
+        Constants.ALLOWED_METHODS,
+        Constants.BLOCKED_METHODS,
+        Constants.SHOPPER_STATEMENT,
+        Constants.MERCHANT_RETURN_DATA,
+        Constants.BILLING_ADDRESS_TYPE,
+        Constants.DELIVERY_ADDRESS_TYPE,
+        Constants.SHOPPER_TYPE,
+        Constants.OFFSET,
+    )
+    """List of fields to sign payment request form.
+
+    This is used to build the ``merchantSig`` signature. Note that the order of
+    the fields matter to compute the hash with the SHA-1 algorithm.
+    """
+
+    PAYMENT_RETURN_HASH_KEYS = (
+        Constants.AUTH_RESULT,
+        Constants.PSP_REFERENCE,
+        Constants.MERCHANT_REFERENCE,
+        Constants.SKIN_CODE,
+        Constants.MERCHANT_RETURN_DATA,
+    )
+    """List of fields used verify payment result on return URL.
+
+    These fields are given to tye payment return URL by Adyen. It is used to
+    validate that the payment return URL has a valid ``merchantSig`` field.
+    """
+
+    def sign(self, fields):
+        """Sign the given form ``fields`` and return the signature fields.
+
+        .. seealso::
+
+            The :meth:`AbstractSigner.sign` method for usage.
+
+        """
+        signature = ''.join(
+            str(fields.get(key, '')) for key in self.PAYMENT_FORM_HASH_KEYS)
+
+        return {
+            Constants.MERCHANT_SIG: self.compute_hash(signature)
+        }
+
+    def verify(self, fields):
+        """Verify ``fields`` contains the appropriate signatures.
+
+        .. warning::
+
+            This version validate only the ``merchantSig`` signature, given to
+            the payment return URL. Other signature fields are ignored (in
+            particular for notification signature).
+
+        .. seealso::
+
+            The :meth:`AbstractSigner.verify` method for usage.
+
+        """
+        if Constants.MERCHANT_SIG in fields:
+            given_hash = fields[Constants.MERCHANT_SIG]
+            signature = ''.join(
+                str(fields.get(key, ''))
+                for key in self.PAYMENT_RETURN_HASH_KEYS)
+            return given_hash == self.compute_hash(signature)
+
+        return True
+
+    def compute_hash(self, signature):
+        """Compute hash using the ``hashlib.sha1`` algorithm.
+
+        .. seealso::
+
+            The :meth:`AbstractSigner.compute_hash` method for usage.
+
+        """
+        hm = hmac.new(self.secret_key.encode('utf-8'),
+                      signature.encode('utf-8'),
+                      hashlib.sha1)
+        return base64.encodebytes(hm.digest()).strip().decode('utf-8')

--- a/adyen/signers.py
+++ b/adyen/signers.py
@@ -7,6 +7,23 @@ There are currently 2 type of signatures:
 
 Each signer follows different rules to sign payment request form, and to verify
 Adyen return response and Adyen notification.
+
+.. note::
+
+    **About the signature:**
+
+    The data passed, in the form fields, is concatenated into a string,
+    referred to as the “signing string”. The HMAC signature is then computed
+    over using a key that is specified in the Adyen Skin settings (stored
+    into the :attr:`AbstractSigner.secret key`).
+
+    The signature is passed along with the form data and once Adyen receives it
+    they use the key to verify that the data has not been tampered with in
+    transit.
+
+    The signing string should be packed into a binary format containing hex
+    characters, and then base64-encoded for transmission.
+
 """
 import base64
 import hashlib

--- a/docs/adyen/adyen.rst
+++ b/docs/adyen/adyen.rst
@@ -13,6 +13,7 @@ Submodules
    adyen.models
    adyen.scaffold
    adyen.settings_config
+   adyen.signers
 
 Module contents
 ---------------

--- a/docs/adyen/adyen.signers.rst
+++ b/docs/adyen/adyen.signers.rst
@@ -1,0 +1,7 @@
+adyen.signers module
+====================
+
+.. automodule:: adyen.signers
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/howto/configure.rst
+++ b/docs/howto/configure.rst
@@ -32,6 +32,18 @@ Edit your ``settings.py`` to set the following settings:
    Your Adyen Skin's secret key.
 
 
+.. data:: ADYEN_SIGNER_BACKEND
+
+   The Signer backend class as a python path. The signer will be responsible
+   for computing hash for signatures used in the payment request form, and to
+   verify the payment return URL's result.
+
+   By default ``adyen.signers.HMACSha1`` is used, which implement the SHA-1
+   legacy signature for Adyen.
+
+   .. versionadded:: 0.7.0
+
+
 .. data:: ADYEN_ACTION_URL
 
    The URL towards which the Adyen form should be POSTed to initiate the payment

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -37,6 +37,12 @@ class TestAbstractAdyenConfig(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             config.get_skin_secret(request)
 
+    def test_get_signer_backend(self):
+        request = RequestFactory()
+        config = AbstractAdyenConfig()
+        with self.assertRaises(NotImplementedError):
+            config.get_signer_backend(request)
+
     def test_get_ip_address_header(self):
         config = AbstractAdyenConfig()
         with self.assertRaises(NotImplementedError):
@@ -66,6 +72,13 @@ class TestFromSettings(TestCase):
 
     def test_value_passing_works(self):
         assert get_config().get_action_url(None) == 'foo'
+
+    def test_get_signer_backend_default(self):
+        assert get_config().get_signer_backend(None) == 'adyen.signers.HMACSha1'
+
+    @override_settings(ADYEN_SIGNER_BACKEND='adyen.signers.HMACSha256')
+    def test_get_signer_backend_configured(self):
+        assert get_config().get_signer_backend(None) == 'adyen.signers.HMACSha256'
 
     # https://docs.djangoproject.com/en/1.8/topics/testing/tools/#django.test.modify_settings
     # Override settings is needed to let us delete settings on a per-test basis.

--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -91,6 +91,7 @@ class TestAdyenPaymentRedirects(TestCase):
         success, status, details = Scaffold().handle_payment_feedback(request)
 
         assert success
+        assert status == Scaffold.PAYMENT_STATUS_ACCEPTED
         assert details['ip_address'] is None
 
         # After the test there's one authorised transaction and no refused transaction in the DB.

--- a/tests/test_signers_sha1.py
+++ b/tests/test_signers_sha1.py
@@ -1,0 +1,63 @@
+import unittest
+
+from adyen.signers import HMACSha1
+
+
+class TestHMACSha1(unittest.TestCase):
+    def test_sign(self):
+        secret_key = 'oscaroscaroscaro'
+        signer = HMACSha1(secret_key)
+
+        fields = {
+            'merchantReturnData': 123,
+            'paymentAmount': 123,
+            'countryCode': 'fr',
+            'currencyCode': 'EUR',
+            'sessionValidity': '2014-07-31T17:20:00Z',
+            'merchantReference': '00000000123',
+            'shopperEmail': 'test@example.com',
+            'shopperLocale': 'fr',
+            'shopperReference': 789,
+            'resURL': 'https://www.example.com/checkout/return/adyen/',
+            'shipBeforeDate': '2014-08-30',
+            'skinCode': 'cqQJKZpg',
+            'merchantAccount': 'OscaroFR'
+        }
+
+        result = signer.sign(fields)
+
+        assert 'merchantSig' in result
+        assert result['merchantSig'] == 'kKvzRvx7wiPLrl8t8+owcmMuJZM='
+
+    def test_verify_return_authorised(self):
+        secret_key = 'oscaroscaroscaro'
+        signer = HMACSha1(secret_key)
+
+        fields = {
+            'authResult': 'AUTHORISED',
+            'merchantReference': 'WVubjVRFOTPBsLNy33zqliF-vmc:109:00000109',
+            'merchantReturnData': '13894',
+            'merchantSig': '99Y+9EiSuT6W4rd/M3zg/wwwRjw=',
+            'paymentMethod': 'visa',
+            'pspReference': '8814136447235922',
+            'shopperLocale': 'en_GB',
+            'skinCode': '4d72uQqA',
+        }
+
+        assert signer.verify(fields) is True
+
+    def test_verify_return_error(self):
+        secret_key = 'oscaroscaroscaro'
+        signer = HMACSha1(secret_key)
+
+        fields = {
+            'authResult': 'ERROR',
+            'merchantReference': '09016057',
+            'merchantReturnData': '29232',
+            'merchantSig': 'Y2lpKZPCOpK7WAlCVSgUQcJ9+xQ=',
+            'paymentMethod': 'visa',
+            'shopperLocale': 'fr',
+            'skinCode': '4d72uQqA',
+        }
+
+        assert signer.verify(fields) is True


### PR DESCRIPTION
A new module `adyen.signers` is created to handle "signers". What a signer is? It aims to sign and verify communication with Adyen.

This new module contains:

* An AbstractSigner class to define a signer interface,
* A signer implementation using the SHA-1 algorithm.

Since `django-oscar-adyen` supports only the SHA-1 algorithm at the moment, this first commit only contains this version. A future commit/PR will contain an implementation for SHA-256.

The new setting is `ADYEN_SIGNER_BACKEND`: it is the python path to the signer class. By default and to be backward compatible it uses the `adyen.signers.HMACSha1` signer.

To use it, the `PaymentFormRequest` and the `PaymentRedirection` classes have been modified to use `client.signer.sign(fields)`  or `client.signer.verify(fields)` instead of `client._compute_hash(signature)`: the signing is totally delegated to the signer, and not managed by the "interaction" classes.

Note that, at the moment, only the payment form and the payment return data are signed/verified.