### PR TITLE
Add shipping, billing, and shopper extra data

### DIFF
--- a/adyen/constants.py
+++ b/adyen/constants.py
@@ -8,12 +8,10 @@ class Constants:
     ADYEN = 'adyen'
     ALLOWED_METHODS = 'allowedMethods'
     AUTH_RESULT = 'authResult'
-    BILLING_ADDRESS_TYPE = 'billingAddressType'
     BLOCKED_METHODS = 'blockedMethods'
     COUNTRY_CODE = 'countryCode'
     CURRENCY = 'currency'
     CURRENCY_CODE = 'currencyCode'
-    DELIVERY_ADDRESS_TYPE = 'deliveryAddressType'
 
     EVENT_CODE = 'eventCode'
     EVENT_CODE_AUTHORISATION = 'AUTHORISATION'
@@ -25,25 +23,6 @@ class Constants:
     SIGNER = 'signer'
     LIVE = 'live'
 
-    MERCHANT_ACCOUNT = 'merchantAccount'
-    MERCHANT_ACCOUNT_CODE = 'merchantAccountCode'
-    MERCHANT_REFERENCE = 'merchantReference'
-    MERCHANT_RETURN_DATA = 'merchantReturnData'
-    MERCHANT_RETURN_URL = 'resURL'
-    MERCHANT_SIG = 'merchantSig'
-
-    OFFSET = 'offset'
-    OPERATIONS = 'operations'
-    ORIGINAL_REFERENCE = 'originalReference'
-
-    PAYMENT_AMOUNT = 'paymentAmount'
-    PAYMENT_METHOD = 'paymentMethod'
-    PAYMENT_RESULT_AUTHORISED = 'AUTHORISED'
-    PAYMENT_RESULT_REFUSED = 'REFUSED'
-    PAYMENT_RESULT_CANCELLED = 'CANCELLED'
-    PAYMENT_RESULT_PENDING = 'PENDING'
-    PAYMENT_RESULT_ERROR = 'ERROR'
-
     PSP_REFERENCE = 'pspReference'
     TEST_REFERENCE_PREFIX = 'test_AUTHORISATION'
     REASON = 'reason'
@@ -54,13 +33,75 @@ class Constants:
     SHIP_BEFORE_DATE = 'shipBeforeDate'
     ADDITIONAL_DATA_PREFIX = 'additionalData.'
 
-    SHOPPER_EMAIL = 'shopperEmail'
-    SHOPPER_LOCALE = 'shopperLocale'
-    SHOPPER_REFERENCE = 'shopperReference'
-    SHOPPER_STATEMENT = 'shopperStatement'
-    SHOPPER_TYPE = 'shopperType'
+    OFFSET = 'offset'
+    OPERATIONS = 'operations'
+    ORIGINAL_REFERENCE = 'originalReference'
 
     SUCCESS = 'success'
     TEST = 'test'
     TRUE = 'true'
     VALUE = 'value'
+
+    # Payment related constants ---
+
+    PAYMENT_AMOUNT = 'paymentAmount'
+    PAYMENT_METHOD = 'paymentMethod'
+
+    PAYMENT_RESULT_AUTHORISED = 'AUTHORISED'
+    PAYMENT_RESULT_REFUSED = 'REFUSED'
+    PAYMENT_RESULT_CANCELLED = 'CANCELLED'
+    PAYMENT_RESULT_PENDING = 'PENDING'
+    PAYMENT_RESULT_ERROR = 'ERROR'
+
+    # Merchant related constants ---
+
+    MERCHANT_SIG = 'merchantSig'
+
+    MERCHANT_ACCOUNT = 'merchantAccount'
+    MERCHANT_ACCOUNT_CODE = 'merchantAccountCode'
+    MERCHANT_REFERENCE = 'merchantReference'
+    MERCHANT_RETURN_DATA = 'merchantReturnData'
+    MERCHANT_RETURN_URL = 'resURL'
+
+    # Delivery address related constants ---
+
+    DELIVERY_SIG = 'deliveryAddressSig'
+    DELIVERY_ADDRESS_TYPE = 'deliveryAddressType'
+
+    DELIVERY_STREET = 'deliveryAddress.street'
+    DELIVERY_NUMBER = 'deliveryAddress.houseNumberOrName'
+    DELIVERY_CITY = 'deliveryAddress.city'
+    DELIVERY_POSTCODE = 'deliveryAddress.postalCode'
+    DELIVERY_STATE = 'deliveryAddress.stateOrProvince'
+    DELIVERY_COUNTRY = 'deliveryAddress.country'
+
+    # Billing address related constants ---
+
+    BILLING_SIG = 'billingAddressSig'
+    BILLING_ADDRESS_TYPE = 'billingAddressType'
+
+    BILLING_STREET = 'billingAddress.street'
+    BILLING_NUMBER = 'billingAddress.houseNumberOrName'
+    BILLING_CITY = 'billingAddress.city'
+    BILLING_POSTCODE = 'billingAddress.postalCode'
+    BILLING_STATE = 'billingAddress.stateOrProvince'
+    BILLING_COUNTRY = 'billingAddress.country'
+
+    # Shopper related constants ---
+
+    SHOPPER_EMAIL = 'shopperEmail'
+    SHOPPER_LOCALE = 'shopperLocale'
+    SHOPPER_REFERENCE = 'shopperReference'
+    SHOPPER_STATEMENT = 'shopperStatement'
+
+    SHOPPER_SIG = 'shopperSig'
+    SHOPPER_TYPE = 'shopperType'
+
+    SHOPPER_FIRSTNAME = 'shopper.firstName'
+    SHOPPER_INFIX = 'shopper.infix'
+    SHOPPER_LASTNAME = 'shopper.lastName'
+    SHOPPER_GENDER = 'shopper.gender'
+    SHOPPER_BIRTH_DAY = 'shopper.dateOfBirthDayOfMonth'
+    SHOPPER_BIRTH_MONTH = 'shopper.dateOfBirthMonth'
+    SHOPPER_BIRTH_YEAR = 'shopper.dateOfBirthYear'
+    SHOPPER_PHONE = 'shopper.telephoneNumber'

--- a/adyen/gateway.py
+++ b/adyen/gateway.py
@@ -105,10 +105,43 @@ class PaymentFormRequest(BaseInteraction):
         Constants.COUNTRY_CODE,
         Constants.MERCHANT_RETURN_URL,
         Constants.MERCHANT_RETURN_DATA,
-        Constants.BILLING_ADDRESS_TYPE,
-        Constants.DELIVERY_ADDRESS_TYPE,
-        Constants.SHOPPER_TYPE,
         Constants.OFFSET,
+
+        Constants.DELIVERY_SIG,
+        Constants.DELIVERY_ADDRESS_TYPE,
+        Constants.DELIVERY_STREET,
+        Constants.DELIVERY_NUMBER,
+        Constants.DELIVERY_CITY,
+        Constants.DELIVERY_POSTCODE,
+        Constants.DELIVERY_STATE,
+        Constants.DELIVERY_COUNTRY,
+
+        Constants.BILLING_SIG,
+        Constants.BILLING_ADDRESS_TYPE,
+
+        Constants.BILLING_STREET,
+        Constants.BILLING_NUMBER,
+        Constants.BILLING_CITY,
+        Constants.BILLING_POSTCODE,
+        Constants.BILLING_STATE,
+        Constants.BILLING_COUNTRY,
+
+        Constants.SHOPPER_EMAIL,
+        Constants.SHOPPER_LOCALE,
+        Constants.SHOPPER_REFERENCE,
+        Constants.SHOPPER_STATEMENT,
+
+        Constants.SHOPPER_SIG,
+        Constants.SHOPPER_TYPE,
+
+        Constants.SHOPPER_FIRSTNAME,
+        Constants.SHOPPER_INFIX,
+        Constants.SHOPPER_LASTNAME,
+        Constants.SHOPPER_GENDER,
+        Constants.SHOPPER_BIRTH_DAY,
+        Constants.SHOPPER_BIRTH_MONTH,
+        Constants.SHOPPER_BIRTH_YEAR,
+        Constants.SHOPPER_PHONE,
     )
 
     def __init__(self, client, params=None):

--- a/adyen/scaffold.py
+++ b/adyen/scaffold.py
@@ -207,9 +207,9 @@ class Scaffold:
         birthdate = shopper.get('birthdate')
         if all(hasattr(birthdate, attr) for attr in ['day', 'month', 'year']):
             fields.update({
-                Constants.SHOPPER_BIRTH_DAY: birthdate.day,
-                Constants.SHOPPER_BIRTH_MONTH: birthdate.month,
-                Constants.SHOPPER_BIRTH_YEAR: birthdate.year,
+                Constants.SHOPPER_BIRTH_DAY: str(birthdate.day),
+                Constants.SHOPPER_BIRTH_MONTH: str(birthdate.month),
+                Constants.SHOPPER_BIRTH_YEAR: str(birthdate.year),
             })
 
         # By default shopper details are not visible.

--- a/docs/howto/use.rst
+++ b/docs/howto/use.rst
@@ -46,6 +46,31 @@ fields.
    :meth:`adyen.scaffold.Scaffold.get_form_action` and
    :meth:`adyen.scaffold.Scaffold.get_form_fields` for more information.
 
+List of payment data items
+--------------------------
+
++--------------------+-----------------------+--------------------------------+----------+
+| Key                | Adyen Form Field      | Description                    | Required |
++====================+=======================+================================+==========+
+| ``order_number``   | ``merchantReference`` | Order Number                   | Yes      |
++--------------------+-----------------------+--------------------------------+----------+
+| ``client_id``      | ``shopperReference``  | Customer's identifier          | Yes      |
++--------------------+-----------------------+--------------------------------+----------+
+| ``client_email``   | ``shopperEmail``      | Customer's email               | Yes      |
++--------------------+-----------------------+--------------------------------+----------+
+| ``currency_code``  | ``currencyCode``      | Currency code                  | Yes      |
++--------------------+-----------------------+--------------------------------+----------+
+| ``amount``         | ``paymentAmount``     | Payment amount (in cent)       | Yes      |
++--------------------+-----------------------+--------------------------------+----------+
+| ``shopper_locale`` | ``shopperLocale``     | Customer's locale              | Yes      |
++--------------------+-----------------------+--------------------------------+----------+
+| ``country_code``   | ``countryCode``       | Merchant's Country             | Yes      |
++--------------------+-----------------------+--------------------------------+----------+
+| ``source_type``    | ``allowedMethods``    | Selected ``SourceType`` object | No       |
++--------------------+-----------------------+--------------------------------+----------+
+| ``return_url``     | ``resURL``            | Custom Payment Return URL      | No       |
++--------------------+-----------------------+--------------------------------+----------+
+
 
 Handle payment return
 =====================

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -16,6 +16,7 @@ DATABASES = {
 }
 
 OSCAR_DEFAULT_CURRENCY = 'EUR'
+OSCAR_REQUIRED_ADDRESS_FIELDS = []
 
 MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -1,0 +1,113 @@
+import datetime
+import unittest
+
+from oscar.apps.order.models import BillingAddress, ShippingAddress
+
+from adyen.constants import Constants
+from adyen.scaffold import Scaffold
+
+
+class TestScaffold(unittest.TestCase):
+
+    def test_get_fields_delivery(self):
+        scaffold = Scaffold()
+
+        address = ShippingAddress(
+            first_name='First Name',
+            last_name='Last Name',
+            line1='First Line Address',
+            line4='Bruxelles',
+            postcode='1000',
+            country_id='BE')
+
+        order_data = {
+            'shipping_address': address
+        }
+        fields = scaffold.get_fields_delivery(None, order_data)
+
+        assert Constants.DELIVERY_STREET in fields
+        assert Constants.DELIVERY_NUMBER in fields
+        assert Constants.DELIVERY_CITY in fields
+        assert Constants.DELIVERY_POSTCODE in fields
+        assert Constants.DELIVERY_STATE in fields
+        assert Constants.DELIVERY_COUNTRY in fields
+
+        assert fields[Constants.DELIVERY_STREET] == address.line1
+        assert fields[Constants.DELIVERY_NUMBER] == '.', (
+            'Since Oscar does not provide a street number we set a fake value')
+        assert fields[Constants.DELIVERY_CITY] == address.city
+        assert fields[Constants.DELIVERY_POSTCODE] == address.postcode
+        assert fields[Constants.DELIVERY_STATE] == address.state
+        assert fields[Constants.DELIVERY_COUNTRY] == address.country_id
+
+    def test_get_fields_billing(self):
+        scaffold = Scaffold()
+
+        address = BillingAddress(
+            first_name='First Name',
+            last_name='Last Name',
+            line1='First Line Address',
+            line4='Bruxelles',
+            postcode='1000',
+            country_id='BE')
+
+        order_data = {
+            'billing_address': address
+        }
+        fields = scaffold.get_fields_billing(None, order_data)
+
+        assert Constants.BILLING_STREET in fields
+        assert Constants.BILLING_NUMBER in fields
+        assert Constants.BILLING_CITY in fields
+        assert Constants.BILLING_POSTCODE in fields
+        assert Constants.BILLING_STATE in fields
+        assert Constants.BILLING_COUNTRY in fields
+
+        assert fields[Constants.BILLING_STREET] == address.line1
+        assert fields[Constants.BILLING_NUMBER] == '.', (
+            'Since Oscar does not provide a street number we set a fake value')
+        assert fields[Constants.BILLING_CITY] == address.city
+        assert fields[Constants.BILLING_POSTCODE] == address.postcode
+        assert fields[Constants.BILLING_STATE] == address.state
+        assert fields[Constants.BILLING_COUNTRY] == address.country_id
+
+    def test_get_fields_shopper(self):
+        scaffold = Scaffold()
+
+        shopper = {
+            'first_name': 'First Name',
+            'last_name': 'Last Name',
+        }
+
+        order_data = {
+            'adyen_shopper': shopper
+        }
+        fields = scaffold.get_fields_shopper(None, order_data)
+
+        assert Constants.SHOPPER_FIRSTNAME in fields
+        assert Constants.SHOPPER_INFIX in fields
+        assert Constants.SHOPPER_LASTNAME in fields
+        assert Constants.SHOPPER_GENDER in fields
+        assert Constants.SHOPPER_BIRTH_DAY in fields
+        assert Constants.SHOPPER_BIRTH_MONTH in fields
+        assert Constants.SHOPPER_BIRTH_YEAR in fields
+        assert Constants.SHOPPER_PHONE in fields
+
+        assert fields[Constants.SHOPPER_FIRSTNAME] == 'First Name'
+        assert fields[Constants.SHOPPER_INFIX] == ''
+        assert fields[Constants.SHOPPER_LASTNAME] == 'Last Name'
+        assert fields[Constants.SHOPPER_GENDER] == ''
+        assert fields[Constants.SHOPPER_BIRTH_DAY] == ''
+        assert fields[Constants.SHOPPER_BIRTH_MONTH] == ''
+        assert fields[Constants.SHOPPER_BIRTH_YEAR] == ''
+        assert fields[Constants.SHOPPER_PHONE] == ''
+
+        shopper['birthdate'] = datetime.date(1815, 12, 10)
+        order_data = {
+            'adyen_shopper': shopper
+        }
+        fields = scaffold.get_fields_shopper(None, order_data)
+
+        assert fields[Constants.SHOPPER_BIRTH_DAY] == '10'
+        assert fields[Constants.SHOPPER_BIRTH_MONTH] == '12'
+        assert fields[Constants.SHOPPER_BIRTH_YEAR] == '1815'

--- a/tests/test_signers_sha1.py
+++ b/tests/test_signers_sha1.py
@@ -90,6 +90,118 @@ class TestHMACSha1(unittest.TestCase):
         assert result['shopperSig'] == initial_shopper_sig, (
             'shopperSig must not be modified with shopperType field added')
 
+    def test_sign_with_delivery(self):
+        secret_key = 'oscaroscaroscaro'
+        signer = HMACSha1(secret_key)
+
+        fields = {
+            'merchantReturnData': 123,
+            'paymentAmount': 123,
+            'countryCode': 'fr',
+            'currencyCode': 'EUR',
+            'sessionValidity': '2014-07-31T17:20:00Z',
+            'merchantReference': '00000000123',
+            'shopperEmail': 'test@example.com',
+            'shopperLocale': 'fr',
+            'shopperReference': 789,
+            'resURL': 'https://www.example.com/checkout/return/adyen/',
+            'shipBeforeDate': '2014-08-30',
+            'skinCode': 'cqQJKZpg',
+            'merchantAccount': 'OscaroFR'
+        }
+
+        result = signer.sign(fields)
+        initial_signature = result['merchantSig']
+
+        fields.update({
+            'deliveryAddress.street': 'something something street',
+            'deliveryAddress.houseNumberOrName': '123',
+            'deliveryAddress.city': 'Townsville',
+            'deliveryAddress.postalCode': '30000',
+            'deliveryAddress.stateOrProvince': 'Georgia',
+            'deliveryAddress.country': 'US',
+        })
+
+        # Regenerate signatures
+        result = signer.sign(fields)
+        assert result['merchantSig'] == initial_signature, (
+            'Signature must not be modified with new deliveryAddress.* fields')
+        assert 'deliveryAddressSig' in result, (
+            'We expect a deliveryAddressSig since deliveryAddress.* fields '
+            'are given.')
+        assert result['deliveryAddressSig'] == 'zZUOyuRdIQ8odnPDRfV5warlXQk='
+
+        initial_delivery_sig = result['deliveryAddressSig']
+
+        # Add a delivery type: the initial signature is modified
+        fields.update({
+            'deliveryAddressType': '2'  # Not visible
+        })
+        result = signer.sign(fields)
+        assert result['merchantSig'] != initial_signature, (
+            'Signature must be modified with deliveryAddressType field added.')
+        assert result['merchantSig'] == '1C4z/P7viArcR/ocW1qtz5iSBa0='
+
+        assert result['deliveryAddressSig'] == initial_delivery_sig, (
+            'deliveryAddressSig must not be modified with deliveryAddressType '
+            'field added')
+
+    def test_sign_with_billing(self):
+        secret_key = 'oscaroscaroscaro'
+        signer = HMACSha1(secret_key)
+
+        fields = {
+            'merchantReturnData': 123,
+            'paymentAmount': 123,
+            'countryCode': 'fr',
+            'currencyCode': 'EUR',
+            'sessionValidity': '2014-07-31T17:20:00Z',
+            'merchantReference': '00000000123',
+            'shopperEmail': 'test@example.com',
+            'shopperLocale': 'fr',
+            'shopperReference': 789,
+            'resURL': 'https://www.example.com/checkout/return/adyen/',
+            'shipBeforeDate': '2014-08-30',
+            'skinCode': 'cqQJKZpg',
+            'merchantAccount': 'OscaroFR'
+        }
+
+        result = signer.sign(fields)
+        initial_signature = result['merchantSig']
+
+        fields.update({
+            'billingAddress.street': 'something something street',
+            'billingAddress.houseNumberOrName': '123',
+            'billingAddress.city': 'Townsville',
+            'billingAddress.postalCode': '30000',
+            'billingAddress.stateOrProvince': 'Georgia',
+            'billingAddress.country': 'US',
+        })
+
+        # Regenerate signatures
+        result = signer.sign(fields)
+        assert result['merchantSig'] == initial_signature, (
+            'Signature must not be modified with new billingAddress.* fields')
+        assert 'billingAddressSig' in result, (
+            'We expect a billingAddressSig since billingAddress.* fields '
+            'are given.')
+        assert result['billingAddressSig'] == 'zZUOyuRdIQ8odnPDRfV5warlXQk='
+
+        initial_billing_sig = result['billingAddressSig']
+
+        # Add a billing type: the initial signature is modified
+        fields.update({
+            'billingAddressType': '2'  # Not visible
+        })
+        result = signer.sign(fields)
+        assert result['merchantSig'] != initial_signature, (
+            'Signature must be modified with billingAddressType field added.')
+        assert result['merchantSig'] == '1C4z/P7viArcR/ocW1qtz5iSBa0='
+
+        assert result['billingAddressSig'] == initial_billing_sig, (
+            'billingAddressSig must not be modified with billingAddressType '
+            'field added')
+
     def test_verify_return_authorised(self):
         secret_key = 'oscaroscaroscaro'
         signer = HMACSha1(secret_key)

--- a/tests/test_signers_sha1.py
+++ b/tests/test_signers_sha1.py
@@ -29,6 +29,67 @@ class TestHMACSha1(unittest.TestCase):
         assert 'merchantSig' in result
         assert result['merchantSig'] == 'kKvzRvx7wiPLrl8t8+owcmMuJZM='
 
+        # Make sure no extra signature fields are given when not required.
+        assert 'billingAddressSig' not in result, (
+            'The billingAddressSig must not be generated when '
+            'billingAddress.* fields are not provided.')
+        assert 'deliveryAddressSig' not in result, (
+            'The deliveryAddressSig must not be generated when '
+            'deliveryAddress.* fields are not provided.')
+        assert 'shopperSig' not in result, (
+            'The shopperSig must not be generated when '
+            'shopper.* fields are not provided.')
+
+    def test_sign_with_shopper(self):
+        secret_key = 'oscaroscaroscaro'
+        signer = HMACSha1(secret_key)
+
+        fields = {
+            'merchantReturnData': 123,
+            'paymentAmount': 123,
+            'countryCode': 'fr',
+            'currencyCode': 'EUR',
+            'sessionValidity': '2014-07-31T17:20:00Z',
+            'merchantReference': '00000000123',
+            'shopperEmail': 'test@example.com',
+            'shopperLocale': 'fr',
+            'shopperReference': 789,
+            'resURL': 'https://www.example.com/checkout/return/adyen/',
+            'shipBeforeDate': '2014-08-30',
+            'skinCode': 'cqQJKZpg',
+            'merchantAccount': 'OscaroFR'
+        }
+
+        result = signer.sign(fields)
+        initial_signature = result['merchantSig']
+
+        fields.update({
+            'shopper.firstName': 'First Name',
+            'shopper.lastName': 'Last Name',
+        })
+
+        # Regenerate signatures
+        result = signer.sign(fields)
+        assert result['merchantSig'] == initial_signature, (
+            'Signature must not be modified with new shopper.* fields')
+        assert 'shopperSig' in result, (
+            'We expect a shopperSig since shopper.* fields are given.')
+        assert result['shopperSig'] == 'CQoNDSMwBbcKAzVgyJqdEWvKDBI='
+
+        initial_shopper_sig = result['shopperSig']
+
+        # Add a shopper type: the initial signature is modified
+        fields.update({
+            'shopperType': '2'  # Not visible
+        })
+        result = signer.sign(fields)
+        assert result['merchantSig'] != initial_signature, (
+            'Signature must be modified with shopperType field added.')
+        assert result['merchantSig'] == '1C4z/P7viArcR/ocW1qtz5iSBa0='
+
+        assert result['shopperSig'] == initial_shopper_sig, (
+            'shopperSig must not be modified with shopperType field added')
+
     def test_verify_return_authorised(self):
         secret_key = 'oscaroscaroscaro'
         signer = HMACSha1(secret_key)


### PR DESCRIPTION
Reading the Adyen documentation, we need to handle more fields: `shopper.*`, `deliveryAddress.*` and `billingAddres.*` fields. They are used by open-invoice with HPP, and in a discussion with Adyen, they requires the shipping address and the shopper's first and last names when using Paypal and a pickup-up point delivery address.

Yeah, I know it looks kind of a specific case, but I tried to implement it for everyone.

The format of the `adyen_shopper` is not described, but the `shipping_address` and the `billing_address` are the order's shipping & billing address objects.

I reminds me that we need more documentation about the "payment" data required to build the Payment Request Form.